### PR TITLE
feature(project): publish all jars shadowed

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,4 @@
+import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 import net.minecrell.gradle.licenser.LicenseExtension
 import org.jetbrains.dokka.gradle.DokkaTask
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
@@ -8,6 +9,7 @@ plugins {
   id("org.jetbrains.dokka")
   id("net.minecrell.licenser") apply false
   id("org.jmailen.kotlinter") apply false
+  id("com.github.johnrengelman.shadow") apply false
 }
 
 repositories {
@@ -26,6 +28,7 @@ subprojects {
   apply(plugin = "org.jetbrains.dokka")
   apply(plugin = "net.minecrell.licenser")
   apply(plugin = "org.jmailen.kotlinter")
+  apply(plugin = "com.github.johnrengelman.shadow")
 
   group = "io.outfoxx.sunday"
   version = releaseVersion
@@ -112,6 +115,10 @@ subprojects {
   }
 
 
+  //
+  // PUBLISHING
+  //
+
   configure<PublishingExtension> {
     repositories {
       maven {
@@ -121,11 +128,6 @@ subprojects {
           username = project.findProperty("github.user") as String? ?: System.getenv("USERNAME")
           password = project.findProperty("github.token") as String? ?: System.getenv("GITHUB_TOKEN")
         }
-      }
-    }
-    publications {
-      create<MavenPublication>("gpr") {
-        from(components["java"])
       }
     }
   }

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -1,8 +1,8 @@
+import com.github.jengelman.gradle.plugins.shadow.ShadowExtension
 
 plugins {
   application
   id("com.google.cloud.tools.jib")
-  id("com.github.johnrengelman.shadow")
 }
 
 val cliktVersion: String by project
@@ -13,7 +13,7 @@ val hamcrestVersion: String by project
 
 dependencies {
 
-  implementation(project(":generator"))
+  implementation(project(path = ":generator", configuration = "shadow"))
 
   implementation("com.github.ajalt.clikt:clikt:$cliktVersion")
   implementation("org.slf4j:slf4j-jdk14:$slf4jVersion")
@@ -36,6 +36,18 @@ application {
   mainClass.set("io.outfoxx.sunday.generator.MainKt")
   mainClassName = "io.outfoxx.sunday.generator.MainKt"
 }
+
+
+publishing {
+  publications {
+    create<MavenPublication>("gpr") {
+      the<ShadowExtension>().component(this)
+      artifact(tasks.named("sourcesJar"))
+      artifact(tasks.named("javadocJar"))
+    }
+  }
+}
+
 
 jib {
   to {

--- a/generator/build.gradle.kts
+++ b/generator/build.gradle.kts
@@ -1,3 +1,5 @@
+import com.github.jengelman.gradle.plugins.shadow.ShadowExtension
+import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 
 plugins {
   `java-library`
@@ -64,4 +66,24 @@ dependencies {
   testImplementation("com.github.docker-java:docker-java-transport-httpclient5:$dockerJavaVersion")
   testImplementation("com.github.tschuchortdev:kotlin-compile-testing:$kotlinCompileTestingVersion")
 
+}
+
+
+tasks {
+  withType<ShadowJar> {
+    dependencies {
+      exclude(dependency("org.jetbrains.kotlin:kotlin-.*:.*"))
+    }
+  }
+}
+
+
+publishing {
+  publications {
+    create<MavenPublication>("gpr") {
+      the<ShadowExtension>().component(this)
+      artifact(tasks.named("sourcesJar"))
+      artifact(tasks.named("javadocJar"))
+    }
+  }
 }

--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -9,9 +9,9 @@ val kotlinCompileTestingVersion: String by project
 
 dependencies {
 
-  compileOnly(localGroovy())
+  shadow(gradleApi())
 
-  implementation(project(":generator"))
+  implementation(project(path = ":generator", configuration = "shadow"))
 
   //
   // TESTING
@@ -26,11 +26,22 @@ dependencies {
   testImplementation("com.github.tschuchortdev:kotlin-compile-testing:$kotlinCompileTestingVersion")
 }
 
+
 gradlePlugin {
   plugins {
     register("sunday") {
       id = "io.outfoxx.sunday-generator"
       implementationClass = "io.outfoxx.sunday.generator.gradle.SundayGeneratorPlugin"
+    }
+  }
+}
+
+
+tasks {
+  shadowJar {
+    dependencies {
+      exclude(dependency(project.dependencies.gradleApi()))
+      exclude(dependency("org.jetbrains.kotlin:kotlin-.*:.*"))
     }
   }
 }


### PR DESCRIPTION
* Ensures CLI is easy to run (without extra jars)
* Ensures Gradle plugin only needs pulling from a single repository