### PR TITLE
feature(kotlin/jaxrs): add `jsonBody` annotation for overriding body type

### DIFF
--- a/generator/src/main/kotlin/io/outfoxx/sunday/generator/APIAnnotationName.kt
+++ b/generator/src/main/kotlin/io/outfoxx/sunday/generator/APIAnnotationName.kt
@@ -60,6 +60,7 @@ enum class APIAnnotationName(val id: String, private val modeSpecific: Boolean) 
   Asynchronous("asynchronous", false),
   Reactive("reactive", false),
   SSE("sse", false),
+  JsonBody("jsonBody", true),
 
   ;
 

--- a/generator/src/main/kotlin/io/outfoxx/sunday/generator/kotlin/KotlinJAXRSGenerator.kt
+++ b/generator/src/main/kotlin/io/outfoxx/sunday/generator/kotlin/KotlinJAXRSGenerator.kt
@@ -26,6 +26,7 @@ import amf.client.model.domain.SecurityRequirement
 import amf.client.model.domain.SecurityScheme
 import amf.client.model.domain.Shape
 import amf.client.model.domain.UnionShape
+import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.squareup.kotlinpoet.AnnotationSpec
 import com.squareup.kotlinpoet.ClassName
@@ -39,6 +40,7 @@ import com.squareup.kotlinpoet.UNIT
 import com.squareup.kotlinpoet.asTypeName
 import io.outfoxx.sunday.generator.APIAnnotationName.Asynchronous
 import io.outfoxx.sunday.generator.APIAnnotationName.EventStream
+import io.outfoxx.sunday.generator.APIAnnotationName.JsonBody
 import io.outfoxx.sunday.generator.APIAnnotationName.Patchable
 import io.outfoxx.sunday.generator.APIAnnotationName.Reactive
 import io.outfoxx.sunday.generator.APIAnnotationName.SSE
@@ -462,6 +464,11 @@ class KotlinJAXRSGenerator(
         .addMember("value = [%L]", mediaTypesForPayloads.joinToString(",") { "\"$it\"" })
         .build()
       functionBuilder.addAnnotation(prodAnn)
+    }
+
+    if (operation.findBoolAnnotation(JsonBody, generationMode) == true) {
+      val orig = parameterBuilder.build()
+      return ParameterSpec.builder(orig.name, JsonNode::class.java).build()
     }
 
     // Finalize

--- a/generator/src/main/resources/sunday.raml
+++ b/generator/src/main/resources/sunday.raml
@@ -191,3 +191,13 @@ annotationTypes:
   nullify:
     type: Nullify
     allowedTargets: [Method]
+
+  jsonBody:
+    type: boolean
+    allowedTargets: [Method]
+  jsonBody:client:
+    type: boolean
+    allowedTargets: [Method]
+  jsonBody:server:
+    type: boolean
+    allowedTargets: [Method]

--- a/generator/src/test/kotlin/io/outfoxx/sunday/generator/kotlin/jaxrs/RequestBodyParamTest.kt
+++ b/generator/src/test/kotlin/io/outfoxx/sunday/generator/kotlin/jaxrs/RequestBodyParamTest.kt
@@ -81,6 +81,113 @@ class RequestBodyParamTest {
   }
 
   @Test
+  fun `test body parameter generation with json override (server mode)`(
+    @ResourceUri("raml/resource-gen/req-body-param-json-override.raml") testUri: URI
+  ) {
+
+    val typeRegistry = KotlinTypeRegistry("io.test", GenerationMode.Server, setOf())
+
+    val builtTypes =
+      generate(testUri, typeRegistry) { document ->
+        KotlinJAXRSGenerator(
+          document,
+          typeRegistry,
+          kotlinJAXRSTestOptions,
+        )
+      }
+
+    val typeSpec = findType("io.test.service.API", builtTypes)
+
+    assertEquals(
+      """
+        package io.test.service
+
+        import com.fasterxml.jackson.databind.JsonNode
+        import io.test.Test
+        import javax.ws.rs.Consumes
+        import javax.ws.rs.GET
+        import javax.ws.rs.Path
+        import javax.ws.rs.Produces
+        import javax.ws.rs.core.Response
+
+        @Produces(value = ["application/json"])
+        @Consumes(value = ["application/json"])
+        public interface API {
+          @GET
+          @Path(value = "/tests")
+          public fun fetchTest(body: JsonNode): Response
+
+          @GET
+          @Path(value = "/tests-client")
+          public fun fetchTestClient(body: Test): Response
+
+          @GET
+          @Path(value = "/tests-server")
+          public fun fetchTestServer(body: JsonNode): Response
+        }
+
+      """.trimIndent(),
+      buildString {
+        FileSpec.get("io.test.service", typeSpec)
+          .writeTo(this)
+      }
+    )
+  }
+
+  @Test
+  fun `test body parameter generation with json override (client mode)`(
+    @ResourceUri("raml/resource-gen/req-body-param-json-override.raml") testUri: URI
+  ) {
+
+    val typeRegistry = KotlinTypeRegistry("io.test", GenerationMode.Client, setOf())
+
+    val builtTypes =
+      generate(testUri, typeRegistry) { document ->
+        KotlinJAXRSGenerator(
+          document,
+          typeRegistry,
+          kotlinJAXRSTestOptions,
+        )
+      }
+
+    val typeSpec = findType("io.test.service.API", builtTypes)
+
+    assertEquals(
+      """
+        package io.test.service
+
+        import com.fasterxml.jackson.databind.JsonNode
+        import io.test.Test
+        import javax.ws.rs.Consumes
+        import javax.ws.rs.GET
+        import javax.ws.rs.Path
+        import javax.ws.rs.Produces
+
+        @Produces(value = ["application/json"])
+        @Consumes(value = ["application/json"])
+        public interface API {
+          @GET
+          @Path(value = "/tests")
+          public fun fetchTest(body: JsonNode): Test
+
+          @GET
+          @Path(value = "/tests-client")
+          public fun fetchTestClient(body: JsonNode): Test
+
+          @GET
+          @Path(value = "/tests-server")
+          public fun fetchTestServer(body: Test): Test
+        }
+
+      """.trimIndent(),
+      buildString {
+        FileSpec.get("io.test.service", typeSpec)
+          .writeTo(this)
+      }
+    )
+  }
+
+  @Test
   fun `test basic body parameter generation with validation constraints`(
     @ResourceUri("raml/resource-gen/req-body-param.raml") testUri: URI
   ) {

--- a/generator/src/test/resources/raml/resource-gen/req-body-param-json-override.raml
+++ b/generator/src/test/resources/raml/resource-gen/req-body-param-json-override.raml
@@ -1,0 +1,43 @@
+#%RAML 1.0
+title: Test API
+uses:
+  sunday: https://outfoxx.github.io/sunday-generator/sunday.raml
+mediaType:
+- application/json
+
+types:
+
+  Test:
+    type: object
+    properties:
+      value1: string
+      value2: integer
+
+
+/tests:
+  get:
+    displayName: fetchTest
+    body: Test
+    responses:
+      200:
+        body:
+          type: Test
+    (sunday.jsonBody): true
+/tests-client:
+  get:
+    displayName: fetchTestClient
+    body: Test
+    responses:
+      200:
+        body:
+          type: Test
+    (sunday.jsonBody:client): true
+/tests-server:
+  get:
+    displayName: fetchTestServer
+    body: Test
+    responses:
+      200:
+        body:
+          type: Test
+    (sunday.jsonBody:server): true


### PR DESCRIPTION
`jsonBody` generates the body type as Jackson `JsonNode`. This allows complex handling of the body parameter when needed. The annotation is also mode specific.