### PR TITLE
Swift Updates

### DIFF
--- a/generator/src/main/kotlin/io/outfoxx/sunday/generator/APIAnnotationName.kt
+++ b/generator/src/main/kotlin/io/outfoxx/sunday/generator/APIAnnotationName.kt
@@ -32,6 +32,9 @@ enum class APIAnnotationName(val id: String, private val modeSpecific: Boolean) 
   TypeScriptType("typeScriptType", false),
   TypeScriptImpl("typeScriptImplementation", false),
 
+  SwiftModule("swiftModule", false),
+  SwiftModelModule("swiftModelModule", false),
+
   SwiftType("swiftType", false),
   SwiftImpl("swiftImplementation", false),
 

--- a/generator/src/main/kotlin/io/outfoxx/sunday/generator/swift/SwiftGenerator.kt
+++ b/generator/src/main/kotlin/io/outfoxx/sunday/generator/swift/SwiftGenerator.kt
@@ -35,6 +35,8 @@ import io.outfoxx.sunday.generator.APIAnnotationName.ProblemBaseUriParams
 import io.outfoxx.sunday.generator.APIAnnotationName.ProblemTypes
 import io.outfoxx.sunday.generator.APIAnnotationName.Problems
 import io.outfoxx.sunday.generator.APIAnnotationName.ServiceGroup
+import io.outfoxx.sunday.generator.APIAnnotationName.SwiftModelModule
+import io.outfoxx.sunday.generator.APIAnnotationName.SwiftModule
 import io.outfoxx.sunday.generator.Generator
 import io.outfoxx.sunday.generator.ProblemTypeDefinition
 import io.outfoxx.sunday.generator.common.NameGenerator
@@ -105,7 +107,11 @@ abstract class SwiftGenerator(
 
       val serviceSimpleName = "${groupName?.replaceFirstChar { it.titlecase() } ?: ""}${options.serviceSuffix}"
 
-      val serviceTypeName = DeclaredTypeName.typeName(".$serviceSimpleName")
+      val serviceModuleName =
+        api.findStringAnnotation(SwiftModule, null)
+          ?: ""
+
+      val serviceTypeName = DeclaredTypeName.typeName("$serviceModuleName.$serviceSimpleName")
 
       val serviceTypeBuilder = generateServiceType(serviceTypeName, endPoints)
 
@@ -556,9 +562,11 @@ abstract class SwiftGenerator(
           val name = variable.name ?: "uriParameter$idx"
 
           val variableTypeName =
-            variable.schema?.let {
-              val suggestedName = "${variable.name?.kotlinTypeName}URIParameter"
-              resolveTypeName(it, DeclaredTypeName.typeName(".$suggestedName"))
+            variable.schema?.let { shape ->
+              val suggestedModuleName = api.findStringAnnotation(SwiftModelModule, null) ?: ""
+              val suggestedName = variable.name?.let { "${it}URIParameter".kotlinTypeName } ?: name.kotlinTypeName
+              val suggestedTypeName = DeclaredTypeName.typeName("$suggestedModuleName.$suggestedName")
+              resolveTypeName(shape, suggestedTypeName)
             } ?: STRING
 
           val defaultValue =

--- a/generator/src/main/kotlin/io/outfoxx/sunday/generator/swift/SwiftTypeRegistry.kt
+++ b/generator/src/main/kotlin/io/outfoxx/sunday/generator/swift/SwiftTypeRegistry.kt
@@ -1215,8 +1215,11 @@ class SwiftTypeRegistry(
       val patchFields = mutableListOf<CodeBlock>()
 
       for (propertyDecl in propertyContainerShape.properties) {
-        val propertyTypeName = resolveReferencedTypeName(propertyDecl.range, context)
-        val optionalPropertyTypeName = propertyTypeName.makeOptional()
+        var propertyTypeName = resolveReferencedTypeName(propertyDecl.range, context)
+        if (propertyDecl.optional) {
+          propertyTypeName = propertyTypeName.wrapOptional()
+        }
+        val optionalPropertyTypeName = propertyTypeName.wrapOptional()
 
         patchClassBuilder.addProperty(propertyDecl.swiftIdentifierName, optionalPropertyTypeName)
         patchClassConsBuilder.addParameter(propertyDecl.swiftIdentifierName, optionalPropertyTypeName)

--- a/generator/src/main/resources/sunday.raml
+++ b/generator/src/main/resources/sunday.raml
@@ -110,6 +110,13 @@ annotationTypes:
     type: TypeImplementation
     allowedTargets: [TypeDeclaration]
 
+  swiftModule:
+    type: string
+    allowedTargets: [API, Extension, Library, Overlay, TypeDeclaration]
+  swiftModelModule:
+    type: string
+    allowedTargets: [API, Extension, Library, Overlay, TypeDeclaration]
+
   swiftType:
     type: string
     allowedTargets: [TypeDeclaration]

--- a/generator/src/test/kotlin/io/outfoxx/sunday/generator/kotlin/RamlTypeAnnotationsTest.kt
+++ b/generator/src/test/kotlin/io/outfoxx/sunday/generator/kotlin/RamlTypeAnnotationsTest.kt
@@ -711,19 +711,26 @@ class RamlTypeAnnotationsTest {
         public class Test(
           public val string: String,
           public val int: Int,
-          public val bool: Boolean
+          public val bool: Boolean,
+          public val nullable: String?,
+          public val optional: String?
         ) {
           public fun copy(
             string: String? = null,
             int: Int? = null,
-            bool: Boolean? = null
-          ) = Test(string ?: this.string, int ?: this.int, bool ?: this.bool)
+            bool: Boolean? = null,
+            nullable: String? = null,
+            optional: String? = null
+          ) = Test(string ?: this.string, int ?: this.int, bool ?: this.bool, nullable ?: this.nullable,
+              optional ?: this.optional)
 
           public override fun hashCode(): Int {
             var result = 1
             result = 31 * result + string.hashCode()
             result = 31 * result + int.hashCode()
             result = 31 * result + bool.hashCode()
+            result = 31 * result + (nullable?.hashCode() ?: 0)
+            result = 31 * result + (optional?.hashCode() ?: 0)
             return result
           }
 
@@ -736,6 +743,8 @@ class RamlTypeAnnotationsTest {
             if (string != other.string) return false
             if (int != other.int) return false
             if (bool != other.bool) return false
+            if (nullable != other.nullable) return false
+            if (optional != other.optional) return false
 
             return true
           }
@@ -743,20 +752,26 @@ class RamlTypeAnnotationsTest {
           public override fun toString() = ""${'"'}
           |Test(string='${'$'}string',
           | int='${'$'}int',
-          | bool='${'$'}bool')
+          | bool='${'$'}bool',
+          | nullable='${'$'}nullable',
+          | optional='${'$'}optional')
           ""${'"'}.trimMargin()
 
           public fun patch(source: ObjectNode): Patch = Patch(
-            if (source.has("string")) Optional.ofNullable(string) else null,
-            if (source.has("int")) Optional.ofNullable(int) else null,
-            if (source.has("bool")) Optional.ofNullable(bool) else null
+            if (source.has("string")) string else null,
+            if (source.has("int")) int else null,
+            if (source.has("bool")) bool else null,
+            if (source.has("nullable")) Optional.ofNullable(nullable) else null,
+            if (source.has("optional")) Optional.ofNullable(optional) else null
           )
 
           @JsonInclude(JsonInclude.Include.NON_NULL)
           public data class Patch(
-            public val string: Optional<String>? = null,
-            public val int: Optional<Int>? = null,
-            public val bool: Optional<Boolean>? = null
+            public val string: String? = null,
+            public val int: Int? = null,
+            public val bool: Boolean? = null,
+            public val nullable: Optional<String>? = null,
+            public val optional: Optional<String>? = null
           )
         }
         

--- a/generator/src/test/kotlin/io/outfoxx/sunday/generator/swift/RamlTypeAnnotationsTest.kt
+++ b/generator/src/test/kotlin/io/outfoxx/sunday/generator/swift/RamlTypeAnnotationsTest.kt
@@ -54,6 +54,40 @@ class RamlTypeAnnotationsTest {
   }
 
   @Test
+  fun `test module annotation`(
+    compiler: SwiftCompiler,
+    @ResourceUri("raml/type-gen/annotations/type-swift-module.raml") testUri: URI
+  ) {
+
+    val typeRegistry = SwiftTypeRegistry(setOf())
+
+    val types = generateTypes(testUri, typeRegistry, compiler)
+
+    val apiTypes = types.filter { it.key.simpleName == "API" }.toList()
+    val modelTypes = types.filterNot { it.key.simpleName == "API" }.toList()
+
+    assertEquals("Explicit", apiTypes.first().first.moduleName)
+    assertEquals("", modelTypes.first().first.moduleName)
+  }
+
+  @Test
+  fun `test model module annotation`(
+    compiler: SwiftCompiler,
+    @ResourceUri("raml/type-gen/annotations/type-swift-model-module.raml") testUri: URI
+  ) {
+
+    val typeRegistry = SwiftTypeRegistry(setOf())
+
+    val types = generateTypes(testUri, typeRegistry, compiler)
+
+    val apiTypes = types.filter { it.key.simpleName == "API" }.toList()
+    val modelTypes = types.filterNot { it.key.simpleName == "API" }.toList()
+
+    assertEquals("", apiTypes.first().first.moduleName)
+    assertEquals("Explicit", modelTypes.first().first.moduleName)
+  }
+
+  @Test
   fun `test class hierarchy generated for 'nested' annotation`(
     compiler: SwiftCompiler,
     @ResourceUri("raml/type-gen/annotations/type-nested.raml") testUri: URI

--- a/generator/src/test/kotlin/io/outfoxx/sunday/generator/swift/RamlTypeAnnotationsTest.kt
+++ b/generator/src/test/kotlin/io/outfoxx/sunday/generator/swift/RamlTypeAnnotationsTest.kt
@@ -1047,22 +1047,30 @@ class RamlTypeAnnotationsTest {
           public let string: String
           public let int: Int
           public let bool: Bool
+          public let nullable: String?
+          public let optional: String?
           public var debugDescription: String {
             return DescriptionBuilder(Test.self)
                 .add(string, named: "string")
                 .add(int, named: "int")
                 .add(bool, named: "bool")
+                .add(nullable, named: "nullable")
+                .add(optional, named: "optional")
                 .build()
           }
 
           public init(
             string: String,
             int: Int,
-            bool: Bool
+            bool: Bool,
+            nullable: String?,
+            optional: String?
           ) {
             self.string = string
             self.int = int
             self.bool = bool
+            self.nullable = nullable
+            self.optional = optional
           }
 
           public required init(from decoder: Decoder) throws {
@@ -1070,6 +1078,8 @@ class RamlTypeAnnotationsTest {
             self.string = try container.decode(String.self, forKey: .string)
             self.int = try container.decode(Int.self, forKey: .int)
             self.bool = try container.decode(Bool.self, forKey: .bool)
+            self.nullable = try container.decodeIfPresent(String.self, forKey: .nullable)
+            self.optional = try container.decodeIfPresent(String.self, forKey: .optional)
           }
 
           public func encode(to encoder: Encoder) throws {
@@ -1077,24 +1087,36 @@ class RamlTypeAnnotationsTest {
             try container.encode(self.string, forKey: .string)
             try container.encode(self.int, forKey: .int)
             try container.encode(self.bool, forKey: .bool)
+            try container.encodeIfPresent(self.nullable, forKey: .nullable)
+            try container.encodeIfPresent(self.optional, forKey: .optional)
           }
 
           public func withString(string: String) -> Test {
-            return Test(string: string, int: int, bool: bool)
+            return Test(string: string, int: int, bool: bool, nullable: nullable, optional: optional)
           }
 
           public func withInt(int: Int) -> Test {
-            return Test(string: string, int: int, bool: bool)
+            return Test(string: string, int: int, bool: bool, nullable: nullable, optional: optional)
           }
 
           public func withBool(bool: Bool) -> Test {
-            return Test(string: string, int: int, bool: bool)
+            return Test(string: string, int: int, bool: bool, nullable: nullable, optional: optional)
+          }
+        
+          public func withNullable(nullable: String?) -> Test {
+            return Test(string: string, int: int, bool: bool, nullable: nullable, optional: optional)
+          }
+        
+          public func withOptional(optional: String?) -> Test {
+            return Test(string: string, int: int, bool: bool, nullable: nullable, optional: optional)
           }
 
           func patch(source: [String : Any]) -> Patch {
             return Patch(string: source.keys.contains("string") ? Optional.some(string) : nil,
                 int: source.keys.contains("int") ? Optional.some(int) : nil,
-                bool: source.keys.contains("bool") ? Optional.some(bool) : nil)
+                bool: source.keys.contains("bool") ? Optional.some(bool) : nil,
+                nullable: source.keys.contains("nullable") ? Optional.some(nullable) : nil,
+                optional: source.keys.contains("optional") ? Optional.some(optional) : nil)
           }
 
           fileprivate enum CodingKeys : String, CodingKey {
@@ -1102,6 +1124,8 @@ class RamlTypeAnnotationsTest {
             case string = "string"
             case int = "int"
             case bool = "bool"
+            case nullable = "nullable"
+            case optional = "optional"
 
           }
 
@@ -1110,15 +1134,21 @@ class RamlTypeAnnotationsTest {
             let string: String?
             let int: Int?
             let bool: Bool?
+            let nullable: String??
+            let optional: String??
 
             init(
               string: String?,
               int: Int?,
-              bool: Bool?
+              bool: Bool?,
+              nullable: String??,
+              optional: String??
             ) {
               self.string = string
               self.int = int
               self.bool = bool
+              self.nullable = nullable
+              self.optional = optional
             }
 
           }

--- a/generator/src/test/kotlin/io/outfoxx/sunday/generator/swift/tools/generator.kt
+++ b/generator/src/test/kotlin/io/outfoxx/sunday/generator/swift/tools/generator.kt
@@ -17,11 +17,14 @@
 package io.outfoxx.sunday.generator.swift.tools
 
 import amf.client.model.document.Document
+import io.outfoxx.sunday.generator.APIAnnotationName
 import io.outfoxx.sunday.generator.GenerationMode.Client
 import io.outfoxx.sunday.generator.swift.SwiftGenerator
 import io.outfoxx.sunday.generator.swift.SwiftResolutionContext
 import io.outfoxx.sunday.generator.swift.SwiftTypeRegistry
 import io.outfoxx.sunday.generator.utils.TestAPIProcessing
+import io.outfoxx.sunday.generator.utils.encodes
+import io.outfoxx.sunday.generator.utils.findStringAnnotation
 import io.outfoxx.swiftpoet.DeclaredTypeName
 import io.outfoxx.swiftpoet.TypeSpec
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -39,7 +42,11 @@ fun generateTypes(
 
   val document = TestAPIProcessing.process(uri).document
 
-  val apiTypeName = DeclaredTypeName.typeName(".API")
+  val apiModuleName =
+    document.encodes.findStringAnnotation(APIAnnotationName.SwiftModule, null)
+      ?: ""
+
+  val apiTypeName = DeclaredTypeName.typeName("$apiModuleName.API")
   typeRegistry.addServiceType(apiTypeName, TypeSpec.classBuilder(apiTypeName))
 
   TestAPIProcessing.generateTypes(document, Client, typeRegistry::defineProblemType) { name, shape ->

--- a/generator/src/test/kotlin/io/outfoxx/sunday/generator/typescript/RamlTypeAnnotationsTest.kt
+++ b/generator/src/test/kotlin/io/outfoxx/sunday/generator/typescript/RamlTypeAnnotationsTest.kt
@@ -804,6 +804,10 @@ class RamlTypeAnnotationsTest {
 
           bool: boolean;
 
+          nullable: string | undefined;
+        
+          optional: string | undefined;
+
         }
 
         export class Test implements Test {
@@ -814,25 +818,40 @@ class RamlTypeAnnotationsTest {
 
           bool: boolean;
 
-          constructor(string: string, int: number, bool: boolean) {
+          nullable: string | undefined;
+        
+          optional: string | undefined;
+        
+          constructor(
+              string: string,
+              int: number,
+              bool: boolean,
+              nullable: string | undefined,
+              optional: string | undefined
+          ) {
             this.string = string;
             this.int = int;
             this.bool = bool;
+            this.nullable = nullable;
+            this.optional = optional;
           }
 
           copy(src: Partial<Test>): Test {
-            return new Test(src.string ?? this.string, src.int ?? this.int, src.bool ?? this.bool);
+            return new Test(src.string ?? this.string, src.int ?? this.int, src.bool ?? this.bool,
+                src.nullable ?? this.nullable, src.optional ?? this.optional);
           }
 
           toString(): string {
-            return `Test(string='${'$'}{this.string}', int='${'$'}{this.int}', bool='${'$'}{this.bool}')`;
+            return `Test(string='${'$'}{this.string}', int='${'$'}{this.int}', bool='${'$'}{this.bool}', nullable='${'$'}{this.nullable}', optional='${'$'}{this.optional}')`;
           }
 
           patch(source: Partial<Test>): Test.Patch {
             return new Test.Patch(
               source['string'] !== undefined ? this.string : null,
               source['int'] !== undefined ? this.int : null,
-              source['bool'] !== undefined ? this.bool : null
+              source['bool'] !== undefined ? this.bool : null,
+              source['nullable'] !== undefined ? this.nullable : null,
+              source['optional'] !== undefined ? this.optional : null
             );
           }
 
@@ -842,8 +861,13 @@ class RamlTypeAnnotationsTest {
 
           export class Patch {
 
-            constructor(public string: string | null | undefined, public int: number | null | undefined,
-                public bool: boolean | null | undefined) {
+            constructor(
+                public string: string | null | undefined,
+                public int: number | null | undefined,
+                public bool: boolean | null | undefined,
+                public nullable: string | undefined | null | undefined,
+                public optional: string | null | undefined
+            ) {
             }
 
           }

--- a/generator/src/test/resources/raml/type-gen/annotations/type-patchable.raml
+++ b/generator/src/test/resources/raml/type-gen/annotations/type-patchable.raml
@@ -14,6 +14,8 @@ types:
       string: string
       int: integer
       bool: boolean
+      nullable: string?
+      optional?: string
 
 /tests/{id}:
 

--- a/generator/src/test/resources/raml/type-gen/annotations/type-swift-model-module.raml
+++ b/generator/src/test/resources/raml/type-gen/annotations/type-swift-model-module.raml
@@ -1,0 +1,25 @@
+#%RAML 1.0
+title: Test API
+uses:
+  sunday: https://outfoxx.github.io/sunday-generator/sunday.raml
+mediaType:
+- application/json
+
+(sunday.swiftModelModule): Explicit
+
+types:
+
+  Test:
+    type: object
+    properties:
+      value:
+        type: string
+
+/tests/{id}:
+
+  get:
+    displayName: fetchTest
+    responses:
+      200:
+        body:
+          type: Test

--- a/generator/src/test/resources/raml/type-gen/annotations/type-swift-module.raml
+++ b/generator/src/test/resources/raml/type-gen/annotations/type-swift-module.raml
@@ -1,0 +1,23 @@
+#%RAML 1.0
+title: Test API
+uses:
+  sunday: https://outfoxx.github.io/sunday-generator/sunday.raml
+mediaType:
+- application/json
+
+(sunday.swiftModule): Explicit
+
+types:
+
+  Test:
+    type: object
+    properties:
+      value: string
+
+/tests/{id}:
+
+  get:
+    displayName: fetchTest
+    responses:
+      200:
+        body: Test

--- a/generator/src/test/resources/raml/type-gen/types/obj-inherits-empty-root.raml
+++ b/generator/src/test/resources/raml/type-gen/types/obj-inherits-empty-root.raml
@@ -1,0 +1,29 @@
+#%RAML 1.0
+title: Test API
+mediaType:
+- application/json
+
+types:
+
+  Root:
+    type: object
+
+  Branch:
+    type: Root
+    properties:
+      value: string
+
+  Leaf:
+    type: Branch
+    properties:
+      value2: string
+
+
+/tests/{id}:
+
+  get:
+    displayName: fetchTest
+    responses:
+      200:
+        body:
+          type: Root


### PR DESCRIPTION
Fixes
* Adds `swiftModelModule` & `swiftModule` annotations
* Generation of empty root classes in hierarchy
* Support for nullable & optional properties in patch classes