### PR TITLE
Add proper support for PATCH operations

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -39,7 +39,6 @@ subprojects {
 
   repositories {
     mavenCentral()
-    jcenter()
     maven {
       setUrl("https://repository-master.mulesoft.org/nexus/content/repositories/releases")
     }

--- a/generator/src/main/kotlin/io/outfoxx/sunday/generator/kotlin/KotlinJAXRSGenerator.kt
+++ b/generator/src/main/kotlin/io/outfoxx/sunday/generator/kotlin/KotlinJAXRSGenerator.kt
@@ -42,7 +42,6 @@ import com.squareup.kotlinpoet.asTypeName
 import io.outfoxx.sunday.generator.APIAnnotationName.Asynchronous
 import io.outfoxx.sunday.generator.APIAnnotationName.EventStream
 import io.outfoxx.sunday.generator.APIAnnotationName.JsonBody
-import io.outfoxx.sunday.generator.APIAnnotationName.Patchable
 import io.outfoxx.sunday.generator.APIAnnotationName.Reactive
 import io.outfoxx.sunday.generator.APIAnnotationName.SSE
 import io.outfoxx.sunday.generator.GenerationMode.Client
@@ -71,7 +70,6 @@ import io.outfoxx.sunday.generator.utils.queryParameters
 import io.outfoxx.sunday.generator.utils.request
 import io.outfoxx.sunday.generator.utils.requests
 import io.outfoxx.sunday.generator.utils.required
-import io.outfoxx.sunday.generator.utils.resolve
 import io.outfoxx.sunday.generator.utils.scalarValue
 import io.outfoxx.sunday.generator.utils.schema
 import io.outfoxx.sunday.generator.utils.scheme
@@ -513,19 +511,12 @@ class KotlinJAXRSGenerator(
       functionBuilder.addAnnotation(consAnn)
     }
 
-    val isPatchMethod = operation.method.equals("patch", ignoreCase = true)
-    val isPatchableType = payloadSchema.resolve.findBoolAnnotation(Patchable, generationMode) == true
     val isJsonBodyRequested = operation.findBoolAnnotation(JsonBody, generationMode) == true
 
     return when {
-      (isPatchMethod && isPatchableType && generationMode == Server) || isJsonBodyRequested -> {
+      isJsonBodyRequested -> {
         val orig = parameterBuilder.build()
         ParameterSpec.builder(orig.name, JsonNode::class.java).build()
-      }
-      isPatchMethod && isPatchableType -> {
-        val orig = parameterBuilder.build()
-        val origTypeName = orig.type as ClassName
-        ParameterSpec.builder(orig.name, origTypeName.nestedClass("Patch")).build()
       }
       else -> {
         // Finalize

--- a/generator/src/main/kotlin/io/outfoxx/sunday/generator/swift/utils/SwiftTypes.kt
+++ b/generator/src/main/kotlin/io/outfoxx/sunday/generator/swift/utils/SwiftTypes.kt
@@ -24,6 +24,7 @@ import io.outfoxx.swiftpoet.STRING
 import io.outfoxx.swiftpoet.parameterizedBy
 
 const val SWIFT_MODULE = "Swift"
+val EQUATABLE = typeName("$SWIFT_MODULE.Equatable")
 val CODABLE = typeName("$SWIFT_MODULE.Codable")
 val ENCODABLE = typeName("$SWIFT_MODULE.Encodable")
 val DECODABLE = typeName("$SWIFT_MODULE.Decodable")

--- a/generator/src/main/kotlin/io/outfoxx/sunday/generator/typescript/utils/JacksonJSTypes.kt
+++ b/generator/src/main/kotlin/io/outfoxx/sunday/generator/typescript/utils/JacksonJSTypes.kt
@@ -21,6 +21,8 @@ import io.outfoxx.typescriptpoet.SymbolSpec
 const val JACKSON_PKG = "@outfoxx/jackson-js"
 val JSON_CLASS_TYPE = SymbolSpec.from("JsonClassType@$JACKSON_PKG")
 val JSON_IGNORE = SymbolSpec.from("JsonIgnore@$JACKSON_PKG")
+val JSON_INCLUDE = SymbolSpec.from("JsonInclude@$JACKSON_PKG")
+val JSON_INCLUDE_TYPE = SymbolSpec.from("JsonIncludeType@$JACKSON_PKG")
 val JSON_PROPERTY = SymbolSpec.from("JsonProperty@$JACKSON_PKG")
 val JSON_SUB_TYPES = SymbolSpec.from("JsonSubTypes@$JACKSON_PKG")
 val JSON_TYPE_INFO = SymbolSpec.from("JsonTypeInfo@$JACKSON_PKG")

--- a/generator/src/main/kotlin/io/outfoxx/sunday/generator/utils/WebApiExts.kt
+++ b/generator/src/main/kotlin/io/outfoxx/sunday/generator/utils/WebApiExts.kt
@@ -529,6 +529,7 @@ val PropertyShape.maxCount: Int? get() = this.maxCount().value
 val PropertyShape.patternName: String? get() = this.patternName().value
 val PropertyShape.optional: Boolean get() = (this.minCount ?: 0) == 0
 val PropertyShape.required: Boolean get() = (this.minCount ?: 0) > 0
+val PropertyShape.nullable: Boolean get() = (range.resolve as? UnionShape)?.makesNullable ?: false
 
 //
 val DataNode.anyValue: Any? get() =

--- a/generator/src/test/kotlin/io/outfoxx/sunday/generator/kotlin/jaxrs/RequestMethodsTest.kt
+++ b/generator/src/test/kotlin/io/outfoxx/sunday/generator/kotlin/jaxrs/RequestMethodsTest.kt
@@ -56,7 +56,6 @@ class RequestMethodsTest {
       """
         package io.test
 
-        import com.fasterxml.jackson.databind.JsonNode
         import javax.ws.rs.Consumes
         import javax.ws.rs.DELETE
         import javax.ws.rs.GET
@@ -104,7 +103,7 @@ class RequestMethodsTest {
         
           @PATCH
           @Path(value = "/tests2")
-          public fun patchableTest(body: JsonNode): Response
+          public fun patchableTest(body: PatchableTest): Response
         }
 
       """.trimIndent(),
@@ -182,7 +181,7 @@ class RequestMethodsTest {
         
           @PATCH
           @Path(value = "/tests2")
-          public fun patchableTest(body: PatchableTest.Patch): Test
+          public fun patchableTest(body: PatchableTest): Test
         }
 
       """.trimIndent(),

--- a/generator/src/test/kotlin/io/outfoxx/sunday/generator/kotlin/sunday/RequestMethodsTest.kt
+++ b/generator/src/test/kotlin/io/outfoxx/sunday/generator/kotlin/sunday/RequestMethodsTest.kt
@@ -112,7 +112,7 @@ class RequestMethodsTest {
             pathTemplate = "/tests"
           )
 
-          public suspend fun patchableTest(body: PatchableTest.Patch): Test = this.requestFactory.result(
+          public suspend fun patchableTest(body: PatchableTest): Test = this.requestFactory.result(
             method = Method.Patch,
             pathTemplate = "/tests2",
             body = body,

--- a/generator/src/test/kotlin/io/outfoxx/sunday/generator/swift/RamlArrayTypesTest.kt
+++ b/generator/src/test/kotlin/io/outfoxx/sunday/generator/swift/RamlArrayTypesTest.kt
@@ -49,12 +49,12 @@ class RamlArrayTypesTest {
 
         public class Test : Codable, CustomDebugStringConvertible {
 
-          public let arrayOfStrings: [String]
-          public let arrayOfNullableStrings: [String?]
-          public let nullableArrayOfStrings: [String]?
-          public let nullableArrayOfNullableStrings: [String?]?
-          public let declaredArrayOfStrings: [String]
-          public let declaredArrayOfNullableStrings: [String?]
+          public var arrayOfStrings: [String]
+          public var arrayOfNullableStrings: [String?]
+          public var nullableArrayOfStrings: [String]?
+          public var nullableArrayOfNullableStrings: [String?]?
+          public var declaredArrayOfStrings: [String]
+          public var declaredArrayOfNullableStrings: [String?]
           public var debugDescription: String {
             return DescriptionBuilder(Test.self)
                 .add(arrayOfStrings, named: "arrayOfStrings")
@@ -187,10 +187,10 @@ class RamlArrayTypesTest {
 
         public class Test : Codable, CustomDebugStringConvertible {
 
-          public let implicit: [String]
-          public let unspecified: [String]
-          public let nonUnique: [String]
-          public let unique: Set<String>
+          public var implicit: [String]
+          public var unspecified: [String]
+          public var nonUnique: [String]
+          public var unique: Set<String>
           public var debugDescription: String {
             return DescriptionBuilder(Test.self)
                 .add(implicit, named: "implicit")
@@ -280,8 +280,8 @@ class RamlArrayTypesTest {
 
         public class Test : Codable, CustomDebugStringConvertible {
 
-          public let binary: Data
-          public let nullableBinary: Data?
+          public var binary: Data
+          public var nullableBinary: Data?
           public var debugDescription: String {
             return DescriptionBuilder(Test.self)
                 .add(binary, named: "binary")

--- a/generator/src/test/kotlin/io/outfoxx/sunday/generator/swift/RamlDiscriminatedTypesTest.kt
+++ b/generator/src/test/kotlin/io/outfoxx/sunday/generator/swift/RamlDiscriminatedTypesTest.kt
@@ -151,8 +151,8 @@ class RamlDiscriminatedTypesTest {
           public override var type: String {
             return "Child1"
           }
-          public let value: String?
-          public let value1: Int
+          public var value: String?
+          public var value1: Int
           public override var debugDescription: String {
             return DescriptionBuilder(Child1.self)
                 .add(type, named: "type")
@@ -217,8 +217,8 @@ class RamlDiscriminatedTypesTest {
           public override var type: String {
             return "child2"
           }
-          public let value: String?
-          public let value2: Int
+          public var value: String?
+          public var value2: Int
           public override var debugDescription: String {
             return DescriptionBuilder(Child2.self)
                 .add(type, named: "type")
@@ -384,7 +384,7 @@ class RamlDiscriminatedTypesTest {
           public override var type: `Type` {
             return `Type`.child1
           }
-          public let value: String?
+          public var value: String?
           public override var debugDescription: String {
             return DescriptionBuilder(Child1.self)
                 .add(type, named: "type")
@@ -440,7 +440,7 @@ class RamlDiscriminatedTypesTest {
           public override var type: `Type` {
             return `Type`.child2
           }
-          public let value: String?
+          public var value: String?
           public override var debugDescription: String {
             return DescriptionBuilder(Child2.self)
                 .add(type, named: "type")

--- a/generator/src/test/kotlin/io/outfoxx/sunday/generator/swift/RamlObjectTypesTest.kt
+++ b/generator/src/test/kotlin/io/outfoxx/sunday/generator/swift/RamlObjectTypesTest.kt
@@ -52,7 +52,7 @@ class RamlObjectTypesTest {
 
         public class Test : Codable, CustomDebugStringConvertible {
 
-          public let map: [String : Any]
+          public var map: [String : Any]
           public var debugDescription: String {
             return DescriptionBuilder(Test.self)
                 .add(map, named: "map")
@@ -111,8 +111,8 @@ class RamlObjectTypesTest {
 
         public class Test : Codable, CustomDebugStringConvertible {
 
-          public let fromNilUnion: String?
-          public let notRequired: String?
+          public var fromNilUnion: String?
+          public var notRequired: String?
           public var debugDescription: String {
             return DescriptionBuilder(Test.self)
                 .add(fromNilUnion, named: "fromNilUnion")
@@ -170,8 +170,8 @@ class RamlObjectTypesTest {
         
         public class Test2 : Codable, CustomDebugStringConvertible {
         
-          public let optionalObject: [String : Any]?
-          public let nillableObject: [String : Any]?
+          public var optionalObject: [String : Any]?
+          public var nillableObject: [String : Any]?
           public var debugDescription: String {
             return DescriptionBuilder(Test2.self)
                 .add(optionalObject, named: "optionalObject")
@@ -281,7 +281,7 @@ class RamlObjectTypesTest {
 
         public class Test : Codable, CustomDebugStringConvertible {
 
-          public let value: String
+          public var value: String
           public var debugDescription: String {
             return DescriptionBuilder(Test.self)
                 .add(value, named: "value")
@@ -327,7 +327,7 @@ class RamlObjectTypesTest {
 
         public class Test2 : Test {
 
-          public let value2: String
+          public var value2: String
           public override var debugDescription: String {
             return DescriptionBuilder(Test2.self)
                 .add(value, named: "value")
@@ -423,7 +423,7 @@ class RamlObjectTypesTest {
 
         public class Test3 : Empty {
 
-          public let value3: String
+          public var value3: String
           public override var debugDescription: String {
             return DescriptionBuilder(Test3.self)
                 .add(value, named: "value")
@@ -535,7 +535,7 @@ class RamlObjectTypesTest {
 
         public class Branch : Root {
 
-          public let value: String
+          public var value: String
           public override var debugDescription: String {
             return DescriptionBuilder(Branch.self)
                 .add(value, named: "value")
@@ -584,7 +584,7 @@ class RamlObjectTypesTest {
 
         public class Leaf : Branch {
 
-          public let value2: String
+          public var value2: String
           public override var debugDescription: String {
             return DescriptionBuilder(Leaf.self)
                 .add(value, named: "value")
@@ -649,8 +649,8 @@ class RamlObjectTypesTest {
 
         public class Test : Codable, CustomDebugStringConvertible {
 
-          public let someValue: String
-          public let anotherValue: String
+          public var someValue: String
+          public var anotherValue: String
           public var debugDescription: String {
             return DescriptionBuilder(Test.self)
                 .add(someValue, named: "someValue")

--- a/generator/src/test/kotlin/io/outfoxx/sunday/generator/swift/RamlScalarTypesTest.kt
+++ b/generator/src/test/kotlin/io/outfoxx/sunday/generator/swift/RamlScalarTypesTest.kt
@@ -51,11 +51,11 @@ class RamlScalarTypesTest {
 
         public class Test : Codable, CustomDebugStringConvertible {
 
-          public let bool: Bool
-          public let string: String
-          public let file: Data
-          public let any: AnyValue
-          public let `nil`: Void
+          public var bool: Bool
+          public var string: String
+          public var file: Data
+          public var any: AnyValue
+          public var `nil`: Void
           public var debugDescription: String {
             return DescriptionBuilder(Test.self)
                 .add(bool, named: "bool")
@@ -152,13 +152,13 @@ class RamlScalarTypesTest {
 
         public class Test : Codable, CustomDebugStringConvertible {
 
-          public let int8: Int8
-          public let int16: Int16
-          public let int32: Int32
-          public let int64: Int64
-          public let int: Int
-          public let long: Int64
-          public let none: Int
+          public var int8: Int8
+          public var int16: Int16
+          public var int32: Int32
+          public var int64: Int64
+          public var int: Int
+          public var long: Int64
+          public var none: Int
           public var debugDescription: String {
             return DescriptionBuilder(Test.self)
                 .add(int8, named: "int8")
@@ -284,9 +284,9 @@ class RamlScalarTypesTest {
 
         public class Test : Codable, CustomDebugStringConvertible {
 
-          public let float: Float
-          public let double: Double
-          public let none: Double
+          public var float: Float
+          public var double: Double
+          public var none: Double
           public var debugDescription: String {
             return DescriptionBuilder(Test.self)
                 .add(float, named: "float")
@@ -366,10 +366,10 @@ class RamlScalarTypesTest {
 
         public class Test : Codable, CustomDebugStringConvertible {
 
-          public let dateOnly: Date
-          public let timeOnly: Date
-          public let dateTimeOnly: Date
-          public let dateTime: Date
+          public var dateOnly: Date
+          public var timeOnly: Date
+          public var dateTimeOnly: Date
+          public var dateTime: Date
           public var debugDescription: String {
             return DescriptionBuilder(Test.self)
                 .add(dateOnly, named: "dateOnly")

--- a/generator/src/test/kotlin/io/outfoxx/sunday/generator/swift/RamlTypeAnnotationsTest.kt
+++ b/generator/src/test/kotlin/io/outfoxx/sunday/generator/swift/RamlTypeAnnotationsTest.kt
@@ -25,6 +25,7 @@ import io.outfoxx.sunday.test.extensions.ResourceUri
 import io.outfoxx.sunday.test.extensions.SwiftCompilerExtension
 import io.outfoxx.swiftpoet.DeclaredTypeName.Companion.typeName
 import io.outfoxx.swiftpoet.FileSpec
+import io.outfoxx.swiftpoet.tag
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.DisplayName
@@ -103,7 +104,7 @@ class RamlTypeAnnotationsTest {
 
         public class Group : Codable, CustomDebugStringConvertible {
 
-          public let value: String
+          public var value: String
           public var debugDescription: String {
             return DescriptionBuilder(Group.self)
                 .add(value, named: "value")
@@ -136,7 +137,7 @@ class RamlTypeAnnotationsTest {
 
           public class Member1 : Group {
 
-            public let memberValue1: String
+            public var memberValue1: String
             public override var debugDescription: String {
               return DescriptionBuilder(Member1.self)
                   .add(value, named: "value")
@@ -177,7 +178,7 @@ class RamlTypeAnnotationsTest {
 
             public class Sub : Member1 {
 
-              public let subMemberValue: String
+              public var subMemberValue: String
               public override var debugDescription: String {
                 return DescriptionBuilder(Sub.self)
                     .add(value, named: "value")
@@ -231,7 +232,7 @@ class RamlTypeAnnotationsTest {
 
           public class Member2 : Group {
 
-            public let memberValue2: String
+            public var memberValue2: String
             public override var debugDescription: String {
               return DescriptionBuilder(Member2.self)
                   .add(value, named: "value")
@@ -298,7 +299,7 @@ class RamlTypeAnnotationsTest {
 
         public class Group : Codable, CustomDebugStringConvertible {
 
-          public let value: String
+          public var value: String
           public var debugDescription: String {
             return DescriptionBuilder(Group.self)
                 .add(value, named: "value")
@@ -331,7 +332,7 @@ class RamlTypeAnnotationsTest {
 
           public class Member1 : Group {
 
-            public let memberValue1: String
+            public var memberValue1: String
             public override var debugDescription: String {
               return DescriptionBuilder(Member1.self)
                   .add(value, named: "value")
@@ -372,7 +373,7 @@ class RamlTypeAnnotationsTest {
 
             public class Sub : Member1 {
 
-              public let subMemberValue: String
+              public var subMemberValue: String
               public override var debugDescription: String {
                 return DescriptionBuilder(Sub.self)
                     .add(value, named: "value")
@@ -426,7 +427,7 @@ class RamlTypeAnnotationsTest {
 
           public class Member2 : Group {
 
-            public let memberValue2: String
+            public var memberValue2: String
             public override var debugDescription: String {
               return DescriptionBuilder(Member2.self)
                   .add(value, named: "value")
@@ -493,7 +494,7 @@ class RamlTypeAnnotationsTest {
 
         public class Root : Codable, CustomDebugStringConvertible {
 
-          public let value: String
+          public var value: String
           public var debugDescription: String {
             return DescriptionBuilder(Root.self)
                 .add(value, named: "value")
@@ -526,7 +527,7 @@ class RamlTypeAnnotationsTest {
 
           public class Group : Codable, CustomDebugStringConvertible {
 
-            public let value: String
+            public var value: String
             public var debugDescription: String {
               return DescriptionBuilder(Group.self)
                   .add(value, named: "value")
@@ -559,7 +560,7 @@ class RamlTypeAnnotationsTest {
 
             public class Member : Codable, CustomDebugStringConvertible {
 
-              public let memberValue: String
+              public var memberValue: String
               public var debugDescription: String {
                 return DescriptionBuilder(Member.self)
                     .add(memberValue, named: "memberValue")
@@ -620,7 +621,7 @@ class RamlTypeAnnotationsTest {
 
         public class Root : Codable, CustomDebugStringConvertible {
 
-          public let value: String
+          public var value: String
           public var debugDescription: String {
             return DescriptionBuilder(Root.self)
                 .add(value, named: "value")
@@ -653,7 +654,7 @@ class RamlTypeAnnotationsTest {
 
           public class Group : Codable, CustomDebugStringConvertible {
 
-            public let value: String
+            public var value: String
             public var debugDescription: String {
               return DescriptionBuilder(Group.self)
                   .add(value, named: "value")
@@ -686,7 +687,7 @@ class RamlTypeAnnotationsTest {
 
             public class Member : Codable, CustomDebugStringConvertible {
 
-              public let memberValue: String
+              public var memberValue: String
               public var debugDescription: String {
                 return DescriptionBuilder(Member.self)
                     .add(memberValue, named: "memberValue")
@@ -832,7 +833,7 @@ class RamlTypeAnnotationsTest {
           public override var type: String {
             return "Child1"
           }
-          public let value: String?
+          public var value: String?
           public override var debugDescription: String {
             return DescriptionBuilder(Child1.self)
                 .add(type, named: "type")
@@ -888,7 +889,7 @@ class RamlTypeAnnotationsTest {
           public override var type: String {
             return "child2"
           }
-          public let value: String?
+          public var value: String?
           public override var debugDescription: String {
             return DescriptionBuilder(Child2.self)
                 .add(type, named: "type")
@@ -941,8 +942,8 @@ class RamlTypeAnnotationsTest {
 
         public class Test : Codable, CustomDebugStringConvertible {
 
-          public let parent: Parent
-          public let parentType: String
+          public var parent: Parent
+          public var parentType: String
           public var debugDescription: String {
             return DescriptionBuilder(Test.self)
                 .add(parent, named: "parent")
@@ -1044,12 +1045,12 @@ class RamlTypeAnnotationsTest {
 
         public class Test : Codable, CustomDebugStringConvertible {
 
-          public let string: String
-          public let int: Int
-          public let bool: Bool
-          public let nullable: String?
-          public let optional: String?
-          public let nullableOptional: String?
+          public var string: UpdateOp<String>?
+          public var int: UpdateOp<Int>?
+          public var bool: UpdateOp<Bool>?
+          public var nullable: PatchOp<String>?
+          public var optional: UpdateOp<String>?
+          public var nullableOptional: PatchOp<String>?
           public var debugDescription: String {
             return DescriptionBuilder(Test.self)
                 .add(string, named: "string")
@@ -1062,12 +1063,12 @@ class RamlTypeAnnotationsTest {
           }
 
           public init(
-            string: String,
-            int: Int,
-            bool: Bool,
-            nullable: String?,
-            optional: String?,
-            nullableOptional: String?
+            string: UpdateOp<String>? = .none,
+            int: UpdateOp<Int>? = .none,
+            bool: UpdateOp<Bool>? = .none,
+            nullable: PatchOp<String>? = .none,
+            optional: UpdateOp<String>? = .none,
+            nullableOptional: PatchOp<String>? = .none
           ) {
             self.string = string
             self.int = int
@@ -1079,61 +1080,52 @@ class RamlTypeAnnotationsTest {
 
           public required init(from decoder: Decoder) throws {
             let container = try decoder.container(keyedBy: CodingKeys.self)
-            self.string = try container.decode(String.self, forKey: .string)
-            self.int = try container.decode(Int.self, forKey: .int)
-            self.bool = try container.decode(Bool.self, forKey: .bool)
-            self.nullable = try container.decodeIfPresent(String.self, forKey: .nullable)
-            self.optional = try container.decodeIfPresent(String.self, forKey: .optional)
-            self.nullableOptional = try container.decodeIfPresent(String.self, forKey: .nullableOptional)
+            self.string = try container.decodeIfExists(String.self, forKey: .string)
+            self.int = try container.decodeIfExists(Int.self, forKey: .int)
+            self.bool = try container.decodeIfExists(Bool.self, forKey: .bool)
+            self.nullable = try container.decodeIfExists(String.self, forKey: .nullable)
+            self.optional = try container.decodeIfExists(String.self, forKey: .optional)
+            self.nullableOptional = try container.decodeIfExists(String.self, forKey: .nullableOptional)
           }
 
           public func encode(to encoder: Encoder) throws {
             var container = encoder.container(keyedBy: CodingKeys.self)
-            try container.encode(self.string, forKey: .string)
-            try container.encode(self.int, forKey: .int)
-            try container.encode(self.bool, forKey: .bool)
-            try container.encodeIfPresent(self.nullable, forKey: .nullable)
-            try container.encodeIfPresent(self.optional, forKey: .optional)
-            try container.encodeIfPresent(self.nullableOptional, forKey: .nullableOptional)
+            try container.encodeIfExists(self.string, forKey: .string)
+            try container.encodeIfExists(self.int, forKey: .int)
+            try container.encodeIfExists(self.bool, forKey: .bool)
+            try container.encodeIfExists(self.nullable, forKey: .nullable)
+            try container.encodeIfExists(self.optional, forKey: .optional)
+            try container.encodeIfExists(self.nullableOptional, forKey: .nullableOptional)
           }
 
-          public func withString(string: String) -> Test {
+          public func withString(string: UpdateOp<String>?) -> Test {
             return Test(string: string, int: int, bool: bool, nullable: nullable, optional: optional,
                 nullableOptional: nullableOptional)
           }
 
-          public func withInt(int: Int) -> Test {
+          public func withInt(int: UpdateOp<Int>?) -> Test {
             return Test(string: string, int: int, bool: bool, nullable: nullable, optional: optional,
                 nullableOptional: nullableOptional)
           }
 
-          public func withBool(bool: Bool) -> Test {
+          public func withBool(bool: UpdateOp<Bool>?) -> Test {
             return Test(string: string, int: int, bool: bool, nullable: nullable, optional: optional,
                 nullableOptional: nullableOptional)
           }
         
-          public func withNullable(nullable: String?) -> Test {
+          public func withNullable(nullable: PatchOp<String>?) -> Test {
             return Test(string: string, int: int, bool: bool, nullable: nullable, optional: optional,
                 nullableOptional: nullableOptional)
           }
         
-          public func withOptional(optional: String?) -> Test {
+          public func withOptional(optional: UpdateOp<String>?) -> Test {
             return Test(string: string, int: int, bool: bool, nullable: nullable, optional: optional,
                 nullableOptional: nullableOptional)
           }
         
-          public func withNullableOptional(nullableOptional: String?) -> Test {
+          public func withNullableOptional(nullableOptional: PatchOp<String>?) -> Test {
             return Test(string: string, int: int, bool: bool, nullable: nullable, optional: optional,
                 nullableOptional: nullableOptional)
-          }
-
-          func patch(source: [String : Any]) -> Patch {
-            return Patch(string: source.keys.contains("string") ? Optional.some(string) : nil,
-                int: source.keys.contains("int") ? Optional.some(int) : nil,
-                bool: source.keys.contains("bool") ? Optional.some(bool) : nil,
-                nullable: source.keys.contains("nullable") ? Optional.some(nullable) : nil,
-                optional: source.keys.contains("optional") ? Optional.some(optional) : nil,
-                nullableOptional: source.keys.contains("nullableOptional") ? Optional.some(nullableOptional) : nil)
           }
 
           fileprivate enum CodingKeys : String, CodingKey {
@@ -1147,38 +1139,32 @@ class RamlTypeAnnotationsTest {
 
           }
 
-          public struct Patch : Codable {
+        }
+        
+        extension AnyPatchOp where Value == Test {
 
-            let string: String?
-            let int: Int?
-            let bool: Bool?
-            let nullable: String??
-            let optional: String??
-            let nullableOptional: String??
-
-            public init(
-              string: String?,
-              int: Int?,
-              bool: Bool?,
-              nullable: String??,
-              optional: String??,
-              nullableOptional: String??
-            ) {
-              self.string = string
-              self.int = int
-              self.bool = bool
-              self.nullable = nullable
-              self.optional = optional
-              self.nullableOptional = nullableOptional
-            }
-
+          public static func merge(
+            string: Sunday.UpdateOp<Swift.String>? = .none,
+            int: Sunday.UpdateOp<Swift.Int>? = .none,
+            bool: Sunday.UpdateOp<Swift.Bool>? = .none,
+            nullable: Sunday.PatchOp<Swift.String>? = .none,
+            optional: Sunday.UpdateOp<Swift.String>? = .none,
+            nullableOptional: Sunday.PatchOp<Swift.String>? = .none
+          ) -> Self {
+            Self.merge(Test(string: string, int: int, bool: bool, nullable: nullable, optional: optional,
+                nullableOptional: nullableOptional))
           }
 
         }
-        
+
       """.trimIndent(),
       buildString {
-        FileSpec.get("", typeSpec)
+        FileSpec.builder("", typeSpec.name)
+          .addType(typeSpec)
+          .apply {
+            typeSpec.tag<AssociatedExtensions>()?.forEach { addExtension(it) }
+          }
+          .build()
           .writeTo(this)
       }
     )

--- a/generator/src/test/kotlin/io/outfoxx/sunday/generator/swift/RamlUnionTypesTest.kt
+++ b/generator/src/test/kotlin/io/outfoxx/sunday/generator/swift/RamlUnionTypesTest.kt
@@ -51,9 +51,9 @@ class RamlUnionTypesTest {
 
         public class Test : Codable, CustomDebugStringConvertible {
 
-          public let any: Any
-          public let duplicate: String
-          public let nullable: String?
+          public var any: Any
+          public var duplicate: String
+          public var nullable: String?
           public var debugDescription: String {
             return DescriptionBuilder(Test.self)
                 .add(any, named: "any")
@@ -132,7 +132,7 @@ class RamlUnionTypesTest {
 
         public class Test : Codable, CustomDebugStringConvertible {
 
-          public let value: Base
+          public var value: Base
           public var debugDescription: String {
             return DescriptionBuilder(Test.self)
                 .add(value, named: "value")

--- a/generator/src/test/kotlin/io/outfoxx/sunday/generator/swift/sunday/RequestMethodsTest.kt
+++ b/generator/src/test/kotlin/io/outfoxx/sunday/generator/swift/sunday/RequestMethodsTest.kt
@@ -165,7 +165,7 @@ class RequestMethodsTest {
             )
           }
 
-          public func patchableTest(body: PatchableTest.Patch) async throws -> Test {
+          public func patchableTest(body: PatchableTest) async throws -> Test {
             return try await self.requestFactory.result(
               method: .patch,
               pathTemplate: "/tests2",

--- a/generator/src/test/kotlin/io/outfoxx/sunday/generator/swift/sunday/ResponseBodyContentTest.kt
+++ b/generator/src/test/kotlin/io/outfoxx/sunday/generator/swift/sunday/ResponseBodyContentTest.kt
@@ -214,7 +214,7 @@ class ResponseBodyContentTest {
 
           public class FetchTestResponseBody : Codable, CustomDebugStringConvertible {
 
-            public let value: String
+            public var value: String
             public var debugDescription: String {
               return DescriptionBuilder(FetchTestResponseBody.self)
                   .add(value, named: "value")

--- a/generator/src/test/kotlin/io/outfoxx/sunday/generator/typescript/RamlObjectTypesTest.kt
+++ b/generator/src/test/kotlin/io/outfoxx/sunday/generator/typescript/RamlObjectTypesTest.kt
@@ -394,11 +394,11 @@ class RamlObjectTypesTest {
 
         export class Test implements Test {
 
-          @JsonProperty({value: 'some-value'})
+          @JsonProperty({value: 'some-value', required: true})
           @JsonClassType({type: () => [String]})
           someValue: string;
 
-          @JsonProperty({value: 'another_value'})
+          @JsonProperty({value: 'another_value', required: true})
           @JsonClassType({type: () => [String]})
           anotherValue: string;
 

--- a/generator/src/test/kotlin/io/outfoxx/sunday/generator/typescript/RamlTypeAnnotationsTest.kt
+++ b/generator/src/test/kotlin/io/outfoxx/sunday/generator/typescript/RamlTypeAnnotationsTest.kt
@@ -858,33 +858,92 @@ class RamlTypeAnnotationsTest {
             return `Test(string='${'$'}{this.string}', int='${'$'}{this.int}', bool='${'$'}{this.bool}', nullable='${'$'}{this.nullable}', optional='${'$'}{this.optional}', nullableOptional='${'$'}{this.nullableOptional}')`;
           }
 
-          patch(source: Partial<Test>): Test.Patch {
-            return new Test.Patch(
-              source['string'] !== undefined ? this.string : null,
-              source['int'] !== undefined ? this.int : null,
-              source['bool'] !== undefined ? this.bool : null,
-              source['nullable'] !== undefined ? this.nullable : null,
-              source['optional'] !== undefined ? this.optional : null,
-              source['nullableOptional'] !== undefined ? this.nullableOptional : null
-            );
-          }
+        }
+        
+      """.trimIndent(),
+      buildString {
+        FileSpec.get(typeSpec)
+          .writeTo(this)
+      }
+    )
+  }
+
+  @Test
+  fun `test patchable class generation with Jackson`(
+    compiler: TypeScriptCompiler,
+    @ResourceUri("raml/type-gen/annotations/type-patchable.raml") testUri: URI
+  ) {
+
+    val typeRegistry = TypeScriptTypeRegistry(setOf(JacksonDecorators))
+
+    val typeSpec = findTypeMod("Test@!test", generateTypes(testUri, typeRegistry, compiler))
+
+    assertEquals(
+      """
+        import {JsonClassType, JsonInclude, JsonIncludeType} from '@outfoxx/jackson-js';
+
+
+        export interface Test {
+
+          string: string;
+
+          int: number;
+
+          bool: boolean;
+
+          nullable: string | null;
+        
+          optional: string | undefined;
+
+          nullableOptional: string | null | undefined;
 
         }
 
-        export namespace Test {
+        @JsonInclude({value: JsonIncludeType.ALWAYS})
+        export class Test implements Test {
 
-          export class Patch {
+          @JsonClassType({type: () => [String]})
+          string: string;
 
-            constructor(
-                public string: string | null | undefined,
-                public int: number | null | undefined,
-                public bool: boolean | null | undefined,
-                public nullable: string | null | undefined,
-                public optional: string | null | undefined,
-                public nullableOptional: string | null | undefined
-            ) {
-            }
+          @JsonClassType({type: () => [Number]})
+          int: number;
 
+          @JsonClassType({type: () => [Boolean]})
+          bool: boolean;
+
+          @JsonClassType({type: () => [String]})
+          nullable: string | null;
+        
+          @JsonClassType({type: () => [String]})
+          optional: string | undefined;
+        
+          @JsonClassType({type: () => [String]})
+          nullableOptional: string | null | undefined;
+
+          constructor(
+              string: string,
+              int: number,
+              bool: boolean,
+              nullable: string | null,
+              optional: string | undefined,
+              nullableOptional: string | null | undefined
+          ) {
+            this.string = string;
+            this.int = int;
+            this.bool = bool;
+            this.nullable = nullable;
+            this.optional = optional;
+            this.nullableOptional = nullableOptional;
+          }
+
+          copy(src: Partial<Test>): Test {
+            return new Test(src.string ?? this.string, src.int ?? this.int, src.bool ?? this.bool,
+                src.nullable ?? this.nullable, src.optional ?? this.optional,
+                src.nullableOptional ?? this.nullableOptional);
+          }
+
+          toString(): string {
+            return `Test(string='${'$'}{this.string}', int='${'$'}{this.int}', bool='${'$'}{this.bool}', nullable='${'$'}{this.nullable}', optional='${'$'}{this.optional}', nullableOptional='${'$'}{this.nullableOptional}')`;
           }
 
         }

--- a/generator/src/test/kotlin/io/outfoxx/sunday/generator/typescript/sunday/RequestMethodsTest.kt
+++ b/generator/src/test/kotlin/io/outfoxx/sunday/generator/typescript/sunday/RequestMethodsTest.kt
@@ -156,7 +156,7 @@ class RequestMethodsTest {
             );
           }
 
-          patchableTest(body: PatchableTest.Patch): Observable<Test> {
+          patchableTest(body: PatchableTest): Observable<Test> {
             return this.requestFactory.result(
                 {
                   method: 'PATCH',

--- a/generator/src/test/resources/swift/compile/local/Package.swift
+++ b/generator/src/test/resources/swift/compile/local/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
         .library(name: "SundayGenTest", targets: ["SundayGenTest"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/outfoxx/sunday-swift.git", from: "1.0.0-beta.9")
+        .package(url: "https://github.com/outfoxx/sunday-swift.git", from: "1.0.0-beta.11")
     ],
     targets: [
         .target(

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@ hamcrestVersion=2.2
 kotlinCompileTestingVersion=1.4.7
 dockerJavaVersion=3.2.7
 
-sundayKtVersion=1.0.0-beta.2
+sundayKtVersion=1.0.0-beta.7
 kotlinCoroutinesVersion=1.4.7
 jaxrsVersion=2.0.1.Final
 validationVersion=1.1.0.Final
@@ -33,7 +33,7 @@ amfClientVersion=4.7.8
 cliktVersion=3.1.0
 kotlinPoetVersion=1.8.0
 typeScriptPoetVersion=1.1.2
-swiftPoetVersion=1.3.1
+swiftPoetVersion=1.4.2
 
 jcolorVersion=5.0.1
 jimfsVersion=1.2


### PR DESCRIPTION
* All libraries provide a framework for patching serializing patch objects
* Generators output patches when the `(patchable)` annotation is present on an object
* Remove all old ad-hoc support (which didn't work properly)