### PR TITLE
Use pre-indexing to support resolved documents including overlays & extensions

### DIFF
--- a/cli/src/main/kotlin/io/outfoxx/sunday/generator/CommonGenerateCommand.kt
+++ b/cli/src/main/kotlin/io/outfoxx/sunday/generator/CommonGenerateCommand.kt
@@ -16,7 +16,7 @@
 
 package io.outfoxx.sunday.generator
 
-import amf.client.model.document.Document
+import amf.core.client.platform.model.document.Document
 import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.parameters.arguments.argument
 import com.github.ajalt.clikt.parameters.arguments.multiple
@@ -28,6 +28,7 @@ import com.github.ajalt.clikt.parameters.options.unique
 import com.github.ajalt.clikt.parameters.types.enum
 import com.github.ajalt.clikt.parameters.types.file
 import io.outfoxx.sunday.generator.common.APIProcessor
+import io.outfoxx.sunday.generator.common.ShapeIndex
 import kotlin.system.exitProcess
 
 abstract class CommonGenerateCommand(name: String, help: String) : CliktCommand(name = name, help = help) {
@@ -71,7 +72,7 @@ abstract class CommonGenerateCommand(name: String, help: String) : CliktCommand(
     .multiple(required = true)
 
   abstract val typeRegistry: TypeRegistry
-  abstract fun generatorFactory(document: Document): Generator
+  abstract fun generatorFactory(document: Document, shapeIndex: ShapeIndex): Generator
 
   override fun run() {
 
@@ -94,7 +95,7 @@ abstract class CommonGenerateCommand(name: String, help: String) : CliktCommand(
         exitProcess(1)
       }
 
-      val generator = generatorFactory(processed.document)
+      val generator = generatorFactory(processed.document, processed.shapeIndex)
 
       try {
         generator.generateServiceTypes()

--- a/cli/src/main/kotlin/io/outfoxx/sunday/generator/kotlin/KotlinGenerateCommand.kt
+++ b/cli/src/main/kotlin/io/outfoxx/sunday/generator/kotlin/KotlinGenerateCommand.kt
@@ -16,13 +16,14 @@
 
 package io.outfoxx.sunday.generator.kotlin
 
-import amf.client.model.document.Document
+import amf.core.client.platform.model.document.Document
 import com.github.ajalt.clikt.parameters.options.multiple
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.required
 import com.github.ajalt.clikt.parameters.types.enum
 import io.outfoxx.sunday.generator.CommonGenerateCommand
 import io.outfoxx.sunday.generator.GenerationMode
+import io.outfoxx.sunday.generator.common.ShapeIndex
 import io.outfoxx.sunday.generator.kotlin.KotlinTypeRegistry.Option.AddGeneratedAnnotation
 import io.outfoxx.sunday.generator.kotlin.KotlinTypeRegistry.Option.ImplementModel
 import io.outfoxx.sunday.generator.kotlin.KotlinTypeRegistry.Option.JacksonAnnotations
@@ -92,7 +93,7 @@ abstract class KotlinGenerateCommand(name: String, help: String) : CommonGenerat
 
   abstract val mode: GenerationMode
 
-  override fun generatorFactory(document: Document) = generatorFactory(document, typeRegistry)
+  override fun generatorFactory(document: Document, shapeIndex: ShapeIndex) = generatorFactory(document, shapeIndex, typeRegistry)
 
-  abstract fun generatorFactory(document: Document, typeRegistry: KotlinTypeRegistry): KotlinGenerator
+  abstract fun generatorFactory(document: Document, shapeIndex: ShapeIndex, typeRegistry: KotlinTypeRegistry): KotlinGenerator
 }

--- a/cli/src/main/kotlin/io/outfoxx/sunday/generator/kotlin/KotlinJAXRSGenerateCommand.kt
+++ b/cli/src/main/kotlin/io/outfoxx/sunday/generator/kotlin/KotlinJAXRSGenerateCommand.kt
@@ -16,12 +16,13 @@
 
 package io.outfoxx.sunday.generator.kotlin
 
-import amf.client.model.document.Document
+import amf.core.client.platform.model.document.Document
 import com.github.ajalt.clikt.parameters.options.default
 import com.github.ajalt.clikt.parameters.options.flag
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.types.enum
 import io.outfoxx.sunday.generator.GenerationMode
+import io.outfoxx.sunday.generator.common.ShapeIndex
 import io.outfoxx.sunday.generator.kotlin.KotlinJAXRSGenerator.Options.BaseUriMode
 import io.outfoxx.sunday.generator.utils.camelCaseToKebabCase
 
@@ -65,9 +66,10 @@ class KotlinJAXRSGenerateCommand :
     help = "Service methods will always use the JAX-RS Response as the return type",
   ).flag(default = false)
 
-  override fun generatorFactory(document: Document, typeRegistry: KotlinTypeRegistry) =
+  override fun generatorFactory(document: Document, shapeIndex: ShapeIndex, typeRegistry: KotlinTypeRegistry) =
     KotlinJAXRSGenerator(
       document,
+      shapeIndex,
       typeRegistry,
       KotlinJAXRSGenerator.Options(
         coroutineServiceMethods,

--- a/cli/src/main/kotlin/io/outfoxx/sunday/generator/kotlin/KotlinSundayGenerateCommand.kt
+++ b/cli/src/main/kotlin/io/outfoxx/sunday/generator/kotlin/KotlinSundayGenerateCommand.kt
@@ -16,17 +16,19 @@
 
 package io.outfoxx.sunday.generator.kotlin
 
-import amf.client.model.document.Document
+import amf.core.client.platform.model.document.Document
 import io.outfoxx.sunday.generator.GenerationMode
+import io.outfoxx.sunday.generator.common.ShapeIndex
 
 class KotlinSundayGenerateCommand :
   KotlinGenerateCommand(name = "kotlin/sunday", help = "Generate Kotlin client for Sunday framework") {
 
   override val mode = GenerationMode.Client
 
-  override fun generatorFactory(document: Document, typeRegistry: KotlinTypeRegistry) =
+  override fun generatorFactory(document: Document, shapeIndex: ShapeIndex, typeRegistry: KotlinTypeRegistry) =
     KotlinSundayGenerator(
       document,
+      shapeIndex,
       typeRegistry,
       KotlinGenerator.Options(
         servicePackageName ?: packageName,

--- a/cli/src/main/kotlin/io/outfoxx/sunday/generator/swift/SwiftGenerateCommand.kt
+++ b/cli/src/main/kotlin/io/outfoxx/sunday/generator/swift/SwiftGenerateCommand.kt
@@ -16,11 +16,12 @@
 
 package io.outfoxx.sunday.generator.swift
 
-import amf.client.model.document.Document
+import amf.core.client.platform.model.document.Document
 import com.github.ajalt.clikt.parameters.options.multiple
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.types.enum
 import io.outfoxx.sunday.generator.CommonGenerateCommand
+import io.outfoxx.sunday.generator.common.ShapeIndex
 import io.outfoxx.sunday.generator.swift.SwiftTypeRegistry.Option.AddGeneratedHeader
 import io.outfoxx.sunday.generator.utils.camelCaseToKebabCase
 
@@ -53,7 +54,7 @@ abstract class SwiftGenerateCommand(name: String, help: String) : CommonGenerate
     SwiftTypeRegistry(options)
   }
 
-  override fun generatorFactory(document: Document) = generatorFactory(document, typeRegistry)
+  override fun generatorFactory(document: Document, shapeIndex: ShapeIndex) = generatorFactory(document, shapeIndex, typeRegistry)
 
-  abstract fun generatorFactory(document: Document, typeRegistry: SwiftTypeRegistry): SwiftGenerator
+  abstract fun generatorFactory(document: Document, shapeIndex: ShapeIndex, typeRegistry: SwiftTypeRegistry): SwiftGenerator
 }

--- a/cli/src/main/kotlin/io/outfoxx/sunday/generator/swift/SwiftSundayGenerateCommand.kt
+++ b/cli/src/main/kotlin/io/outfoxx/sunday/generator/swift/SwiftSundayGenerateCommand.kt
@@ -16,15 +16,17 @@
 
 package io.outfoxx.sunday.generator.swift
 
-import amf.client.model.document.Document
+import amf.core.client.platform.model.document.Document
 import io.outfoxx.sunday.generator.Generator
+import io.outfoxx.sunday.generator.common.ShapeIndex
 
 class SwiftSundayGenerateCommand :
   SwiftGenerateCommand(name = "swift/sunday", help = "Generate Swift client for Sunday framework") {
 
-  override fun generatorFactory(document: Document, typeRegistry: SwiftTypeRegistry) =
+  override fun generatorFactory(document: Document, shapeIndex: ShapeIndex, typeRegistry: SwiftTypeRegistry) =
     SwiftSundayGenerator(
       document,
+      shapeIndex,
       typeRegistry,
       Generator.Options(
         problemBaseUri,

--- a/cli/src/main/kotlin/io/outfoxx/sunday/generator/typescript/TypeScriptGenerateCommand.kt
+++ b/cli/src/main/kotlin/io/outfoxx/sunday/generator/typescript/TypeScriptGenerateCommand.kt
@@ -16,11 +16,12 @@
 
 package io.outfoxx.sunday.generator.typescript
 
-import amf.client.model.document.Document
+import amf.core.client.platform.model.document.Document
 import com.github.ajalt.clikt.parameters.options.multiple
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.types.enum
 import io.outfoxx.sunday.generator.CommonGenerateCommand
+import io.outfoxx.sunday.generator.common.ShapeIndex
 import io.outfoxx.sunday.generator.typescript.TypeScriptTypeRegistry.Option.AddGenerationHeader
 import io.outfoxx.sunday.generator.typescript.TypeScriptTypeRegistry.Option.JacksonDecorators
 import io.outfoxx.sunday.generator.utils.camelCaseToKebabCase
@@ -55,7 +56,7 @@ abstract class TypeScriptGenerateCommand(name: String, help: String) : CommonGen
     TypeScriptTypeRegistry(options)
   }
 
-  override fun generatorFactory(document: Document) = generatorFactory(document, typeRegistry)
+  override fun generatorFactory(document: Document, shapeIndex: ShapeIndex) = generatorFactory(document, shapeIndex, typeRegistry)
 
-  abstract fun generatorFactory(document: Document, typeRegistry: TypeScriptTypeRegistry): TypeScriptGenerator
+  abstract fun generatorFactory(document: Document, shapeIndex: ShapeIndex, typeRegistry: TypeScriptTypeRegistry): TypeScriptGenerator
 }

--- a/cli/src/main/kotlin/io/outfoxx/sunday/generator/typescript/TypeScriptSundayGenerateCommand.kt
+++ b/cli/src/main/kotlin/io/outfoxx/sunday/generator/typescript/TypeScriptSundayGenerateCommand.kt
@@ -16,15 +16,17 @@
 
 package io.outfoxx.sunday.generator.typescript
 
-import amf.client.model.document.Document
+import amf.core.client.platform.model.document.Document
 import io.outfoxx.sunday.generator.Generator
+import io.outfoxx.sunday.generator.common.ShapeIndex
 
 class TypeScriptSundayGenerateCommand :
   TypeScriptGenerateCommand(name = "typescript/sunday", help = "Generate TypeScript client for Sunday framework") {
 
-  override fun generatorFactory(document: Document, typeRegistry: TypeScriptTypeRegistry) =
+  override fun generatorFactory(document: Document, shapeIndex: ShapeIndex, typeRegistry: TypeScriptTypeRegistry) =
     TypeScriptSundayGenerator(
       document,
+      shapeIndex,
       typeRegistry,
       Generator.Options(
         problemBaseUri,

--- a/generator/build.gradle.kts
+++ b/generator/build.gradle.kts
@@ -38,7 +38,9 @@ configurations.compileClasspath {
 
 dependencies {
 
-  api("com.github.amlorg:amf-client_2.12:$amfClientVersion")
+  api("com.github.amlorg:amf-api-contract_2.12:$amfClientVersion")
+
+  api("com.fasterxml.jackson.core:jackson-databind:$jacksonVersion")
 
   api("com.squareup:kotlinpoet:$kotlinPoetVersion")
   api("io.outfoxx:typescriptpoet:$typeScriptPoetVersion")

--- a/generator/src/main/kotlin/io/outfoxx/sunday/generator/Generator.kt
+++ b/generator/src/main/kotlin/io/outfoxx/sunday/generator/Generator.kt
@@ -16,7 +16,7 @@
 
 package io.outfoxx.sunday.generator
 
-import amf.client.model.domain.WebApi
+import amf.apicontract.client.platform.model.domain.api.WebApi
 import io.outfoxx.sunday.generator.utils.accepts
 import io.outfoxx.sunday.generator.utils.contentType
 

--- a/generator/src/main/kotlin/io/outfoxx/sunday/generator/ProblemTypeDefinition.kt
+++ b/generator/src/main/kotlin/io/outfoxx/sunday/generator/ProblemTypeDefinition.kt
@@ -16,9 +16,9 @@
 
 package io.outfoxx.sunday.generator
 
-import amf.client.model.document.BaseUnit
-import amf.client.model.domain.DataNode
-import amf.client.model.domain.ObjectNode
+import amf.core.client.platform.model.document.BaseUnit
+import amf.core.client.platform.model.domain.DataNode
+import amf.core.client.platform.model.domain.ObjectNode
 import io.outfoxx.sunday.generator.utils.get
 import io.outfoxx.sunday.generator.utils.rawScalarValue
 import io.outfoxx.sunday.generator.utils.stringValue

--- a/generator/src/main/kotlin/io/outfoxx/sunday/generator/TypeRegistry.kt
+++ b/generator/src/main/kotlin/io/outfoxx/sunday/generator/TypeRegistry.kt
@@ -16,6 +16,7 @@
 
 package io.outfoxx.sunday.generator
 
+import io.outfoxx.sunday.generator.common.ShapeIndex
 import java.nio.file.Path
 
 interface TypeRegistry {
@@ -24,6 +25,7 @@ interface TypeRegistry {
 
   fun defineProblemType(
     problemCode: String,
-    problemTypeDefinition: ProblemTypeDefinition
+    problemTypeDefinition: ProblemTypeDefinition,
+    shapeIndex: ShapeIndex,
   ): Any
 }

--- a/generator/src/main/kotlin/io/outfoxx/sunday/generator/common/APIAnnotations.kt
+++ b/generator/src/main/kotlin/io/outfoxx/sunday/generator/common/APIAnnotations.kt
@@ -16,7 +16,7 @@
 
 package io.outfoxx.sunday.generator.common
 
-import amf.client.model.domain.DataNode
+import amf.core.client.platform.model.domain.DataNode
 import io.outfoxx.sunday.generator.utils.numberValue
 import io.outfoxx.sunday.generator.utils.stringValue
 

--- a/generator/src/main/kotlin/io/outfoxx/sunday/generator/common/DefinitionLocation.kt
+++ b/generator/src/main/kotlin/io/outfoxx/sunday/generator/common/DefinitionLocation.kt
@@ -16,12 +16,12 @@
 
 package io.outfoxx.sunday.generator.common
 
-import amf.client.model.domain.DomainElement
-import amf.core.parser.Range
+import amf.core.client.platform.model.domain.DomainElement
 import io.outfoxx.sunday.generator.utils.annotations
 import io.outfoxx.sunday.generator.utils.location
+import org.mulesoft.common.client.lexical.PositionRange
 
-data class DefinitionLocation(val location: String, val range: Range) {
+data class DefinitionLocation(val location: String, val range: PositionRange) {
 
   constructor(element: DomainElement) : this(element.annotations.location, element.position())
 

--- a/generator/src/main/kotlin/io/outfoxx/sunday/generator/common/NameGenerator.kt
+++ b/generator/src/main/kotlin/io/outfoxx/sunday/generator/common/NameGenerator.kt
@@ -16,8 +16,8 @@
 
 package io.outfoxx.sunday.generator.common
 
-import amf.client.model.domain.EndPoint
-import amf.client.model.domain.Operation
+import amf.apicontract.client.platform.model.domain.EndPoint
+import amf.apicontract.client.platform.model.domain.Operation
 
 interface NameGenerator {
 

--- a/generator/src/main/kotlin/io/outfoxx/sunday/generator/common/ResolutionContext.kt
+++ b/generator/src/main/kotlin/io/outfoxx/sunday/generator/common/ResolutionContext.kt
@@ -16,20 +16,130 @@
 
 package io.outfoxx.sunday.generator.common
 
-import amf.client.model.document.BaseUnit
-import amf.client.model.domain.DomainElement
+import amf.core.client.platform.model.document.BaseUnit
+import amf.core.client.platform.model.document.DeclaresModel
+import amf.core.client.platform.model.document.ExternalFragment
+import amf.core.client.platform.model.domain.DomainElement
+import amf.core.client.platform.model.domain.NamedDomainElement
+import amf.core.client.platform.model.domain.PropertyShape
+import amf.core.client.platform.model.domain.Shape
+import amf.core.internal.annotations.Aliases
+import amf.shapes.client.platform.model.domain.NodeShape
 import io.outfoxx.sunday.generator.utils.allUnits
-import io.outfoxx.sunday.generator.utils.findDeclaringUnit
-import io.outfoxx.sunday.generator.utils.findImportingUnit
-import io.outfoxx.sunday.generator.utils.resolveRef
+import io.outfoxx.sunday.generator.utils.annotations
+import io.outfoxx.sunday.generator.utils.declares
+import io.outfoxx.sunday.generator.utils.id
+import io.outfoxx.sunday.generator.utils.location
+import io.outfoxx.sunday.generator.utils.name
+import io.outfoxx.sunday.generator.utils.nonPatternProperties
+import scala.collection.JavaConverters
 
 interface ResolutionContext {
 
   val unit: BaseUnit
+  val shapeIndex: ShapeIndex
+
+  fun hasInherited(shape: Shape): Boolean = shapeIndex.hasInherited(shape)
+
+  fun hasNoInherited(shape: Shape): Boolean = shapeIndex.hasNoInherited(shape)
+
+  fun hasNoInheriting(shape: Shape): Boolean = shapeIndex.hasNoInheriting(shape)
+
+  fun findRootShape(shape: Shape): Shape = findSuperShapeOrNull(shape)?.let(this::findRootShape) ?: shape
+
+  fun findSuperShapeOrNull(shape: Shape): Shape? {
+    val superShapeId = shapeIndex.findSuperShapeIdOrNull(shape) ?: return null
+    return unit.allUnits.firstNotNullOf {
+      val found = it.findById(superShapeId)
+      found.orElse(null)
+    } as Shape
+  }
+
+  fun findInheritingShapes(shape: Shape): List<Shape> {
+    return shapeIndex.findInheritingIds(shape).mapNotNull { inheritingId ->
+      unit.allUnits.firstNotNullOfOrNull {
+        val found = it.findById(inheritingId)
+        found.orElse(null)
+      } as Shape?
+    }
+  }
+
+  fun findProperties(shape: NodeShape): List<PropertyShape> {
+
+    val orderedProperties = mutableListOf<PropertyShape>()
+
+    shapeIndex.findOrderOrProperties(shape).forEach { propertyName ->
+      val property = shape.nonPatternProperties.first { it.name == propertyName }
+      orderedProperties.add(property)
+    }
+
+    return orderedProperties
+  }
+
+  fun findAllProperties(shape: NodeShape): List<PropertyShape> {
+    val superShape = findSuperShapeOrNull(shape) as NodeShape?
+    val superProperties = superShape?.let(this::findAllProperties) ?: emptyList()
+    return superProperties + findProperties(shape)
+  }
+
+  fun findDeclaringUnit(element: DomainElement) =
+    unit.allUnits.first { it.location == element.annotations.location }
+
+  fun findImportingUnit(element: DomainElement, allUnits: List<BaseUnit>): BaseUnit? {
+    if (this !is ExternalFragment) return null
+
+    val importingUnitLocation = element.id.split("#", limit = 2).first()
+    return allUnits.find { it.location == importingUnitLocation }
+  }
 
   fun resolveRef(name: String, source: DomainElement): Pair<DomainElement, BaseUnit>? {
-    val sourceUnit = unit.findDeclaringUnit(source)
+    val sourceUnit = findDeclaringUnit(source)
     return sourceUnit.resolveRef(name)
-      ?: sourceUnit.findImportingUnit(source, unit.allUnits)?.resolveRef(name)
+      ?: findImportingUnit(source, unit.allUnits)?.resolveRef(name)
   }
+
+  fun getReferenceTarget(shape: Shape): Shape? {
+    val refTargetId = shapeIndex.findReferenceTargetId(shape) ?: return null
+    unit.allUnits.forEach { unit ->
+      if (unit is DeclaresModel) {
+        unit.declares.forEach { declared ->
+          if (declared is Shape && declared.id == refTargetId) {
+            return declared
+          }
+        }
+      }
+    }
+    return null
+  }
+}
+
+private val ELEMENT_REF_REGEX = """(?:([^.]+)\.)?([\w-_.]+)""".toRegex()
+
+private fun BaseUnit.resolveRef(ref: String): Pair<DomainElement, BaseUnit>? {
+
+  val (libraryName, declarationName) =
+    ELEMENT_REF_REGEX.matchEntire(ref)?.destructured
+      ?: error("Invalid reference '$ref'")
+
+  val declarationUnit =
+    if (libraryName.isBlank()) {
+
+      this as? DeclaresModel
+    } else {
+
+      val aliases: Aliases =
+        annotations._internal().find(Aliases::class.java).getOrElse(null)
+          ?: error("Unable to find unit aliases")
+
+      val unitUrl = JavaConverters.setAsJavaSet(aliases.aliases()).first { it._1 == libraryName }?._2!!.fullUrl()
+
+      allUnits.find { it.location == unitUrl } as? DeclaresModel
+    } ?: return null
+
+  val decl = declarationUnit.declares
+    .filterIsInstance<NamedDomainElement>()
+    .firstOrNull { it.name == declarationName } as? DomainElement
+    ?: return null
+
+  return decl to (declarationUnit as BaseUnit)
 }

--- a/generator/src/main/kotlin/io/outfoxx/sunday/generator/common/ShapeIndex.kt
+++ b/generator/src/main/kotlin/io/outfoxx/sunday/generator/common/ShapeIndex.kt
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2020 Outfox, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.outfoxx.sunday.generator.common
+
+import amf.core.client.platform.model.document.BaseUnit
+import amf.core.client.platform.model.domain.Shape
+import amf.shapes.client.platform.model.domain.NodeShape
+import io.outfoxx.sunday.generator.utils.ShapeVisitor
+import io.outfoxx.sunday.generator.utils.id
+import io.outfoxx.sunday.generator.utils.inherits
+import io.outfoxx.sunday.generator.utils.linkTarget
+import io.outfoxx.sunday.generator.utils.name
+import io.outfoxx.sunday.generator.utils.nonPatternProperties
+import io.outfoxx.sunday.generator.utils.properties
+import io.outfoxx.sunday.generator.utils.range
+
+class ShapeIndex(
+  private val inheritedMap: Map<String, Set<String>>,
+  private val inheritingMap: Map<String, Set<String>>,
+  private val orderOfProperties: Map<String, List<String>>,
+  private val referenceMap: Map<String, String>,
+) {
+
+  companion object {
+
+    fun builder() = Builder()
+  }
+
+  class Builder : ShapeVisitor() {
+
+    private val inheritedMap = mutableMapOf<String, MutableSet<String>>()
+    private val inheritingMap = mutableMapOf<String, MutableSet<String>>()
+    private val orderOfProperties = mutableMapOf<String, List<String>>()
+    private val referenceMap = mutableMapOf<String, String>()
+
+    fun index(baseUnit: BaseUnit): Builder {
+      visit(baseUnit)
+      return this
+    }
+
+    fun build() = ShapeIndex(inheritedMap, inheritingMap, orderOfProperties, referenceMap)
+
+    override fun visit(shape: Shape?) {
+      add(shape)
+    }
+
+    private fun add(shape: Shape?) {
+      shape ?: return
+
+      // Mark and ignore soft links...
+      if (
+        !shape.hasExplicitName() &&
+        shape.inherits.size == 1 &&
+        (shape !is NodeShape || shape.properties.isEmpty())
+      ) {
+        storeReference(shape, dereference(shape.inherits.single()))
+        return
+      }
+
+      val shapeId = shape.id
+
+      if (shape is NodeShape) {
+        orderOfProperties[shapeId] = shape.nonPatternProperties.mapNotNull { it.name }
+
+        shape.properties.forEach { add(dereference(it.range)) }
+      }
+
+      inheritedMap.getOrPut(shapeId) { mutableSetOf() }
+      inheritingMap.getOrPut(shapeId) { mutableSetOf() }
+
+      shape.inherits().forEach { inheritedNode ->
+        val inheritedNodeId = dereference(inheritedNode).id
+        inheritedMap.getOrPut(shapeId) { mutableSetOf() }.add(inheritedNodeId)
+        inheritingMap.getOrPut(inheritedNodeId) { mutableSetOf() }.add(shapeId)
+      }
+    }
+
+    private fun dereference(shape: Shape): Shape =
+      when {
+        shape.linkTarget != null -> dereference(storeReference(shape, shape.linkTarget as Shape))
+
+        else -> shape
+      }
+
+    private fun storeReference(source: Shape, target: Shape): Shape {
+      referenceMap[source.id] = target.id
+      return target
+    }
+  }
+
+  fun hasInherited(shape: Shape): Boolean {
+    return inheritedMap[resolveIfReference(shape)]?.isNotEmpty() ?: false
+  }
+
+  fun hasNoInherited(shape: Shape): Boolean {
+    return !hasInherited(shape)
+  }
+
+  fun findInheritedIds(shape: Shape): Set<String> {
+    return inheritedMap[resolveIfReference(shape)] ?: setOf()
+  }
+
+  fun findSuperShapeIdOrNull(shape: Shape): String? {
+    return findInheritedIds(shape).firstOrNull()
+  }
+
+  fun hasInheriting(shape: Shape): Boolean {
+    return inheritingMap[resolveIfReference(shape)]?.isNotEmpty() ?: false
+  }
+
+  fun hasNoInheriting(shape: Shape): Boolean {
+    return !hasInheriting(shape)
+  }
+
+  fun findInheritingIds(shape: Shape): Set<String> {
+    return inheritingMap[resolveIfReference(shape)] ?: setOf()
+  }
+
+  fun findOrderOrProperties(shape: NodeShape): List<String> {
+    return orderOfProperties[resolveIfReference(shape)] ?: emptyList()
+  }
+
+  fun findReferenceTargetId(shape: Shape): String? {
+    return referenceMap[shape.id]
+  }
+
+  fun resolveIfReference(shape: Shape): String {
+    return findReferenceTargetId(shape) ?: shape.id
+  }
+}

--- a/generator/src/main/kotlin/io/outfoxx/sunday/generator/common/SimpleNameGenerator.kt
+++ b/generator/src/main/kotlin/io/outfoxx/sunday/generator/common/SimpleNameGenerator.kt
@@ -16,8 +16,8 @@
 
 package io.outfoxx.sunday.generator.common
 
-import amf.client.model.domain.EndPoint
-import amf.client.model.domain.Operation
+import amf.apicontract.client.platform.model.domain.EndPoint
+import amf.apicontract.client.platform.model.domain.Operation
 import io.outfoxx.sunday.generator.utils.name
 import io.outfoxx.sunday.generator.utils.operationId
 

--- a/generator/src/main/kotlin/io/outfoxx/sunday/generator/kotlin/KotlinResolutionContext.kt
+++ b/generator/src/main/kotlin/io/outfoxx/sunday/generator/kotlin/KotlinResolutionContext.kt
@@ -16,16 +16,13 @@
 
 package io.outfoxx.sunday.generator.kotlin
 
-import amf.client.model.document.BaseUnit
+import amf.core.client.platform.model.document.BaseUnit
 import com.squareup.kotlinpoet.ClassName
 import io.outfoxx.sunday.generator.common.ResolutionContext
+import io.outfoxx.sunday.generator.common.ShapeIndex
 
 data class KotlinResolutionContext(
   override val unit: BaseUnit,
+  override val shapeIndex: ShapeIndex,
   val suggestedTypeName: ClassName?
-) : ResolutionContext {
-
-  fun copy(suggestedTypeName: ClassName? = null): KotlinResolutionContext {
-    return KotlinResolutionContext(unit, suggestedTypeName)
-  }
-}
+) : ResolutionContext

--- a/generator/src/main/kotlin/io/outfoxx/sunday/generator/kotlin/KotlinSundayGenerator.kt
+++ b/generator/src/main/kotlin/io/outfoxx/sunday/generator/kotlin/KotlinSundayGenerator.kt
@@ -16,18 +16,19 @@
 
 package io.outfoxx.sunday.generator.kotlin
 
-import amf.client.model.document.Document
-import amf.client.model.domain.EndPoint
-import amf.client.model.domain.NodeShape
-import amf.client.model.domain.Operation
-import amf.client.model.domain.Parameter
-import amf.client.model.domain.Response
-import amf.client.model.domain.Shape
-import amf.client.model.domain.UnionShape
+import amf.apicontract.client.platform.model.domain.EndPoint
+import amf.apicontract.client.platform.model.domain.Operation
+import amf.apicontract.client.platform.model.domain.Parameter
+import amf.apicontract.client.platform.model.domain.Response
+import amf.core.client.platform.model.document.Document
+import amf.core.client.platform.model.domain.Shape
+import amf.shapes.client.platform.model.domain.NodeShape
+import amf.shapes.client.platform.model.domain.UnionShape
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.CodeBlock
 import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.KModifier
+import com.squareup.kotlinpoet.KModifier.PUBLIC
 import com.squareup.kotlinpoet.MemberName
 import com.squareup.kotlinpoet.NameAllocator
 import com.squareup.kotlinpoet.ParameterSpec
@@ -46,6 +47,7 @@ import io.outfoxx.sunday.generator.APIAnnotationName.RequestOnly
 import io.outfoxx.sunday.generator.APIAnnotationName.ResponseOnly
 import io.outfoxx.sunday.generator.GenerationMode
 import io.outfoxx.sunday.generator.ProblemTypeDefinition
+import io.outfoxx.sunday.generator.common.ShapeIndex
 import io.outfoxx.sunday.generator.genError
 import io.outfoxx.sunday.generator.kotlin.utils.FLOW
 import io.outfoxx.sunday.generator.kotlin.utils.REQUEST
@@ -63,16 +65,17 @@ import io.outfoxx.sunday.generator.utils.path
 import io.outfoxx.sunday.generator.utils.payloads
 import io.outfoxx.sunday.generator.utils.request
 import io.outfoxx.sunday.generator.utils.requests
-import io.outfoxx.sunday.generator.utils.resolve
 import io.outfoxx.sunday.http.Method
 import java.net.URI
 
 class KotlinSundayGenerator(
   document: Document,
+  shapeIndex: ShapeIndex,
   typeRegistry: KotlinTypeRegistry,
   options: Options
 ) : KotlinGenerator(
   document,
+  shapeIndex,
   typeRegistry,
   options
 ) {
@@ -120,7 +123,7 @@ class KotlinSundayGenerator(
                   ParameterSpec.builder(param.name, paramTypeName)
                     .apply {
                       if (param.defaultValue != null) {
-                        defaultValue(param.defaultValue.kotlinConstant(paramTypeName, param.shape?.resolve))
+                        defaultValue(param.defaultValue.kotlinConstant(paramTypeName, param.shape))
                       }
                     }
                     .build()
@@ -149,7 +152,7 @@ class KotlinSundayGenerator(
 
     serviceTypeBuilder
       .addProperty(
-        PropertySpec.builder("requestFactory", RequestFactory::class, KModifier.PUBLIC)
+        PropertySpec.builder("requestFactory", RequestFactory::class, PUBLIC)
           .initializer("requestFactory")
           .build()
       )
@@ -472,7 +475,7 @@ class KotlinSundayGenerator(
           val typesParams = types.flatMap {
             val typeName = resolveTypeName(it, null)
             val discValue =
-              (it.resolve as? NodeShape)?.discriminatorValue ?: (typeName as? ClassName)?.simpleName ?: "$typeName"
+              (it as? NodeShape)?.discriminatorValue ?: (typeName as? ClassName)?.simpleName ?: "$typeName"
             listOf(discValue, typeName, TYPE_OF, typeName)
           }
 

--- a/generator/src/main/kotlin/io/outfoxx/sunday/generator/kotlin/utils/KotlinDataNodes.kt
+++ b/generator/src/main/kotlin/io/outfoxx/sunday/generator/kotlin/utils/KotlinDataNodes.kt
@@ -16,12 +16,12 @@
 
 package io.outfoxx.sunday.generator.kotlin.utils
 
-import amf.client.model.domain.ArrayNode
-import amf.client.model.domain.DataNode
-import amf.client.model.domain.ObjectNode
-import amf.client.model.domain.ScalarNode
-import amf.client.model.domain.Shape
-import amf.core.model.DataType
+import amf.core.client.platform.model.DataTypes
+import amf.core.client.platform.model.domain.ArrayNode
+import amf.core.client.platform.model.domain.DataNode
+import amf.core.client.platform.model.domain.ObjectNode
+import amf.core.client.platform.model.domain.ScalarNode
+import amf.core.client.platform.model.domain.Shape
 import com.squareup.kotlinpoet.CodeBlock
 import com.squareup.kotlinpoet.TypeName
 import io.outfoxx.sunday.generator.utils.value
@@ -38,9 +38,9 @@ fun DataNode.kotlinConstant(typeName: TypeName, shape: Shape?, builder: CodeBloc
     is ScalarNode ->
       when (dataType().value()) {
 
-        DataType.Nil() -> builder.add("null")
+        DataTypes.Nil() -> builder.add("null")
 
-        DataType.String() ->
+        DataTypes.String() ->
           if (value != null && shape?.values?.isNotEmpty() == true)
             builder.add("%T.%L", typeName, kotlinEnumName)
           else if (value != null)
@@ -48,15 +48,15 @@ fun DataNode.kotlinConstant(typeName: TypeName, shape: Shape?, builder: CodeBloc
           else
             builder.add("null")
 
-        DataType.Date(), DataType.Time(), DataType.DateTime(), DataType.DateTimeOnly() ->
+        DataTypes.Date(), DataTypes.Time(), DataTypes.DateTime(), DataTypes.DateTimeOnly() ->
           if (value != null)
             builder.add("%S", value)
           else
             builder.add("null")
 
-        DataType.Boolean(),
-        DataType.Byte(), DataType.Integer(), DataType.Number(), DataType.Long(),
-        DataType.Double(), DataType.Float(), DataType.Decimal() ->
+        DataTypes.Boolean(),
+        DataTypes.Byte(), DataTypes.Integer(), DataTypes.Number(), DataTypes.Long(),
+        DataTypes.Double(), DataTypes.Float(), DataTypes.Decimal() ->
           if (value != null)
             builder.add("%L", value)
           else

--- a/generator/src/main/kotlin/io/outfoxx/sunday/generator/kotlin/utils/KotlinNaming.kt
+++ b/generator/src/main/kotlin/io/outfoxx/sunday/generator/kotlin/utils/KotlinNaming.kt
@@ -16,11 +16,11 @@
 
 package io.outfoxx.sunday.generator.kotlin.utils
 
-import amf.client.model.domain.Operation
-import amf.client.model.domain.Parameter
-import amf.client.model.domain.PropertyShape
-import amf.client.model.domain.ScalarNode
-import amf.client.model.domain.Shape
+import amf.apicontract.client.platform.model.domain.Operation
+import amf.apicontract.client.platform.model.domain.Parameter
+import amf.core.client.platform.model.domain.PropertyShape
+import amf.core.client.platform.model.domain.ScalarNode
+import amf.core.client.platform.model.domain.Shape
 import io.outfoxx.sunday.generator.utils.name
 import io.outfoxx.sunday.generator.utils.operationId
 import io.outfoxx.sunday.generator.utils.parameterName

--- a/generator/src/main/kotlin/io/outfoxx/sunday/generator/swift/SwiftResolutionContext.kt
+++ b/generator/src/main/kotlin/io/outfoxx/sunday/generator/swift/SwiftResolutionContext.kt
@@ -16,16 +16,13 @@
 
 package io.outfoxx.sunday.generator.swift
 
-import amf.client.model.document.BaseUnit
+import amf.core.client.platform.model.document.BaseUnit
 import io.outfoxx.sunday.generator.common.ResolutionContext
+import io.outfoxx.sunday.generator.common.ShapeIndex
 import io.outfoxx.swiftpoet.DeclaredTypeName
 
 data class SwiftResolutionContext(
   override val unit: BaseUnit,
+  override val shapeIndex: ShapeIndex,
   val suggestedTypeName: DeclaredTypeName?
-) : ResolutionContext {
-
-  fun copy(suggestedTypeName: DeclaredTypeName? = null): SwiftResolutionContext {
-    return SwiftResolutionContext(unit, suggestedTypeName)
-  }
-}
+) : ResolutionContext

--- a/generator/src/main/kotlin/io/outfoxx/sunday/generator/swift/utils/SwiftDataNodes.kt
+++ b/generator/src/main/kotlin/io/outfoxx/sunday/generator/swift/utils/SwiftDataNodes.kt
@@ -16,12 +16,12 @@
 
 package io.outfoxx.sunday.generator.swift.utils
 
-import amf.client.model.domain.ArrayNode
-import amf.client.model.domain.DataNode
-import amf.client.model.domain.ObjectNode
-import amf.client.model.domain.ScalarNode
-import amf.client.model.domain.Shape
-import amf.core.model.DataType
+import amf.core.client.platform.model.DataTypes
+import amf.core.client.platform.model.domain.ArrayNode
+import amf.core.client.platform.model.domain.DataNode
+import amf.core.client.platform.model.domain.ObjectNode
+import amf.core.client.platform.model.domain.ScalarNode
+import amf.core.client.platform.model.domain.Shape
 import io.outfoxx.sunday.generator.utils.value
 import io.outfoxx.sunday.generator.utils.values
 import io.outfoxx.swiftpoet.CodeBlock
@@ -38,9 +38,9 @@ fun DataNode.swiftConstant(typeName: TypeName, shape: Shape?, builder: CodeBlock
     is ScalarNode ->
       when (dataType().value()) {
 
-        DataType.Nil() -> builder.add("null")
+        DataTypes.Nil() -> builder.add("null")
 
-        DataType.String() ->
+        DataTypes.String() ->
           if (value != null && shape?.values?.isNotEmpty() == true)
             builder.add("%T.%L", typeName, swiftIdentifierName)
           else if (value != null)
@@ -48,15 +48,15 @@ fun DataNode.swiftConstant(typeName: TypeName, shape: Shape?, builder: CodeBlock
           else
             builder.add("null")
 
-        DataType.Date(), DataType.Time(), DataType.DateTime(), DataType.DateTimeOnly() ->
+        DataTypes.Date(), DataTypes.Time(), DataTypes.DateTime(), DataTypes.DateTimeOnly() ->
           if (value != null)
             builder.add("%S", value)
           else
             builder.add("null")
 
-        DataType.Boolean(),
-        DataType.Byte(), DataType.Integer(), DataType.Number(), DataType.Long(),
-        DataType.Double(), DataType.Float(), DataType.Decimal() ->
+        DataTypes.Boolean(),
+        DataTypes.Byte(), DataTypes.Integer(), DataTypes.Number(), DataTypes.Long(),
+        DataTypes.Double(), DataTypes.Float(), DataTypes.Decimal() ->
           if (value != null)
             builder.add("%L", value)
           else

--- a/generator/src/main/kotlin/io/outfoxx/sunday/generator/swift/utils/SwiftNaming.kt
+++ b/generator/src/main/kotlin/io/outfoxx/sunday/generator/swift/utils/SwiftNaming.kt
@@ -16,11 +16,11 @@
 
 package io.outfoxx.sunday.generator.swift.utils
 
-import amf.client.model.domain.Operation
-import amf.client.model.domain.Parameter
-import amf.client.model.domain.PropertyShape
-import amf.client.model.domain.ScalarNode
-import amf.client.model.domain.Shape
+import amf.apicontract.client.platform.model.domain.Operation
+import amf.apicontract.client.platform.model.domain.Parameter
+import amf.core.client.platform.model.domain.PropertyShape
+import amf.core.client.platform.model.domain.ScalarNode
+import amf.core.client.platform.model.domain.Shape
 import io.outfoxx.sunday.generator.utils.name
 import io.outfoxx.sunday.generator.utils.operationId
 import io.outfoxx.sunday.generator.utils.parameterName

--- a/generator/src/main/kotlin/io/outfoxx/sunday/generator/typescript/TypeScriptResolutionContext.kt
+++ b/generator/src/main/kotlin/io/outfoxx/sunday/generator/typescript/TypeScriptResolutionContext.kt
@@ -16,16 +16,13 @@
 
 package io.outfoxx.sunday.generator.typescript
 
-import amf.client.model.document.BaseUnit
+import amf.core.client.platform.model.document.BaseUnit
 import io.outfoxx.sunday.generator.common.ResolutionContext
+import io.outfoxx.sunday.generator.common.ShapeIndex
 import io.outfoxx.typescriptpoet.TypeName
 
 data class TypeScriptResolutionContext(
   override val unit: BaseUnit,
+  override val shapeIndex: ShapeIndex,
   val suggestedTypeName: TypeName.Standard?,
-) : ResolutionContext {
-
-  fun copy(suggestedTypeName: TypeName.Standard? = null): TypeScriptResolutionContext {
-    return TypeScriptResolutionContext(unit, suggestedTypeName)
-  }
-}
+) : ResolutionContext

--- a/generator/src/main/kotlin/io/outfoxx/sunday/generator/typescript/utils/TypeScriptDataNodes.kt
+++ b/generator/src/main/kotlin/io/outfoxx/sunday/generator/typescript/utils/TypeScriptDataNodes.kt
@@ -16,12 +16,12 @@
 
 package io.outfoxx.sunday.generator.typescript.utils
 
-import amf.client.model.domain.ArrayNode
-import amf.client.model.domain.DataNode
-import amf.client.model.domain.ObjectNode
-import amf.client.model.domain.ScalarNode
-import amf.client.model.domain.Shape
-import amf.core.model.DataType
+import amf.core.client.platform.model.DataTypes
+import amf.core.client.platform.model.domain.ArrayNode
+import amf.core.client.platform.model.domain.DataNode
+import amf.core.client.platform.model.domain.ObjectNode
+import amf.core.client.platform.model.domain.ScalarNode
+import amf.core.client.platform.model.domain.Shape
 import io.outfoxx.sunday.generator.utils.value
 import io.outfoxx.sunday.generator.utils.values
 import io.outfoxx.typescriptpoet.CodeBlock
@@ -38,9 +38,9 @@ fun DataNode.typeScriptConstant(typeName: TypeName, shape: Shape?, builder: Code
     is ScalarNode ->
       when (dataType().value()) {
 
-        DataType.Nil() -> builder.add("null")
+        DataTypes.Nil() -> builder.add("null")
 
-        DataType.String() ->
+        DataTypes.String() ->
           if (value != null && shape?.values?.isNotEmpty() == true)
             builder.add("%T.%L", typeName, typeScriptEnumName)
           else if (value != null)
@@ -48,15 +48,15 @@ fun DataNode.typeScriptConstant(typeName: TypeName, shape: Shape?, builder: Code
           else
             builder.add("null")
 
-        DataType.Date(), DataType.Time(), DataType.DateTime(), DataType.DateTimeOnly() ->
+        DataTypes.Date(), DataTypes.Time(), DataTypes.DateTime(), DataTypes.DateTimeOnly() ->
           if (value != null)
             builder.add("%S", value)
           else
             builder.add("null")
 
-        DataType.Boolean(),
-        DataType.Byte(), DataType.Integer(), DataType.Number(), DataType.Long(),
-        DataType.Double(), DataType.Float(), DataType.Decimal() ->
+        DataTypes.Boolean(),
+        DataTypes.Byte(), DataTypes.Integer(), DataTypes.Number(), DataTypes.Long(),
+        DataTypes.Double(), DataTypes.Float(), DataTypes.Decimal() ->
           if (value != null)
             builder.add("%L", value)
           else

--- a/generator/src/main/kotlin/io/outfoxx/sunday/generator/typescript/utils/TypeScriptNaming.kt
+++ b/generator/src/main/kotlin/io/outfoxx/sunday/generator/typescript/utils/TypeScriptNaming.kt
@@ -16,11 +16,11 @@
 
 package io.outfoxx.sunday.generator.typescript.utils
 
-import amf.client.model.domain.Operation
-import amf.client.model.domain.Parameter
-import amf.client.model.domain.PropertyShape
-import amf.client.model.domain.ScalarNode
-import amf.client.model.domain.Shape
+import amf.apicontract.client.platform.model.domain.Operation
+import amf.apicontract.client.platform.model.domain.Parameter
+import amf.core.client.platform.model.domain.PropertyShape
+import amf.core.client.platform.model.domain.ScalarNode
+import amf.core.client.platform.model.domain.Shape
 import io.outfoxx.sunday.generator.utils.name
 import io.outfoxx.sunday.generator.utils.operationId
 import io.outfoxx.sunday.generator.utils.parameterName

--- a/generator/src/main/kotlin/io/outfoxx/sunday/generator/utils/CollectionUtils.kt
+++ b/generator/src/main/kotlin/io/outfoxx/sunday/generator/utils/CollectionUtils.kt
@@ -14,27 +14,8 @@
  * limitations under the License.
  */
 
-package io.outfoxx.sunday.generator
+package io.outfoxx.sunday.generator.utils
 
-import amf.core.client.platform.model.domain.DomainElement
-import io.outfoxx.sunday.generator.utils.location
-
-class GenerationException(
-  message: String,
-  val file: String,
-  val line: Int,
-  val column: Int
-) : Exception(message)
-
-fun genError(message: String, element: DomainElement? = null): Nothing {
-  if (element == null) {
-    throw GenerationException(message, "", 0, 0)
-  }
-
-  throw GenerationException(
-    message,
-    element.annotations().location,
-    element.position().start().line(),
-    element.position().start().column()
-  )
+fun <T> Collection<T>.equalsInAnyOrder(other: Collection<T>): Boolean {
+  return size == other.size && containsAll(other)
 }

--- a/generator/src/main/kotlin/io/outfoxx/sunday/generator/utils/LocalResourceLoader.kt
+++ b/generator/src/main/kotlin/io/outfoxx/sunday/generator/utils/LocalResourceLoader.kt
@@ -16,34 +16,26 @@
 
 package io.outfoxx.sunday.generator.utils
 
-import amf.client.remote.Content
-import amf.client.resource.ClientResourceLoader
-import amf.client.resource.FileResourceLoader
-import amf.client.resource.HttpResourceLoader
-import amf.core.remote.FileNotFound
-import amf.core.remote.UnsupportedUrlScheme
+import amf.core.client.common.remote.Content
+import amf.core.client.platform.resource.HttpResourceLoader
+import amf.core.client.platform.resource.ResourceLoader
 import java.util.concurrent.CompletableFuture
 
-object LocalResourceLoader : ClientResourceLoader {
+object LocalResourceLoader : ResourceLoader {
 
-  private val fileLoader = FileResourceLoader()
   private val httpLoader = HttpResourceLoader()
 
+  override fun accepts(resource: String?): Boolean {
+    return resource.equals("https://outfoxx.github.io/sunday-generator/sunday.raml", ignoreCase = true)
+  }
+
   override fun fetch(resource: String): CompletableFuture<Content> {
-    return if (resource.equals("https://outfoxx.github.io/sunday-generator/sunday.raml", ignoreCase = true)) {
-      val bytes = LocalResourceLoader::class.java.getResource("/sunday.raml")?.openStream()?.readAllBytes()
-      if (bytes != null) {
-        val content = Content(String(bytes, Charsets.UTF_8), resource)
-        CompletableFuture.completedFuture(content)
-      } else {
-        httpLoader.fetch(resource)
-      }
-    } else if (resource.startsWith("file:")) {
-      fileLoader.fetch(resource)
-    } else if (resource.startsWith("http:") || resource.startsWith("https:")) {
-      httpLoader.fetch(resource)
+    val bytes = LocalResourceLoader::class.java.getResource("/sunday.raml")?.openStream()?.readAllBytes()
+    return if (bytes != null) {
+      val content = Content(String(bytes, Charsets.UTF_8), resource)
+      CompletableFuture.completedFuture(content)
     } else {
-      throw FileNotFound(UnsupportedUrlScheme(resource))
+      return httpLoader.fetch(resource)
     }
   }
 }

--- a/generator/src/main/kotlin/io/outfoxx/sunday/generator/utils/ShapeVisitor.kt
+++ b/generator/src/main/kotlin/io/outfoxx/sunday/generator/utils/ShapeVisitor.kt
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2020 Outfox, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.outfoxx.sunday.generator.utils
+
+import amf.apicontract.client.platform.model.domain.Callback
+import amf.apicontract.client.platform.model.domain.EndPoint
+import amf.apicontract.client.platform.model.domain.Operation
+import amf.apicontract.client.platform.model.domain.Request
+import amf.apicontract.client.platform.model.domain.Response
+import amf.apicontract.client.platform.model.domain.Server
+import amf.apicontract.client.platform.model.domain.TemplatedLink
+import amf.apicontract.client.platform.model.domain.api.WebApi
+import amf.apicontract.client.platform.model.domain.security.ParametrizedSecurityScheme
+import amf.apicontract.client.platform.model.domain.security.SecurityRequirement
+import amf.apicontract.client.platform.model.domain.security.SecurityScheme
+import amf.core.client.platform.model.document.BaseUnit
+import amf.core.client.platform.model.document.DeclaresModel
+import amf.core.client.platform.model.document.EncodesModel
+import amf.core.client.platform.model.domain.Shape
+
+abstract class ShapeVisitor {
+
+  protected abstract fun visit(shape: Shape?)
+
+  protected fun visit(unit: BaseUnit) {
+
+    unit.references.forEach { visit(it) }
+
+    if (unit is DeclaresModel) {
+
+      unit.declares.forEach { declared ->
+
+        if (declared is Shape) {
+          visit(declared)
+        }
+      }
+    }
+
+    val model = unit as? EncodesModel
+    if (model != null) {
+
+      val api = model.encodes as? WebApi
+
+      api?.servers?.forEach { server -> visit(server) }
+      api?.security?.forEach { securityRequirement -> visit(securityRequirement) }
+      api?.endPoints?.forEach { endPoint -> visit(endPoint) }
+    }
+  }
+
+  protected fun visit(endPoint: EndPoint) {
+    endPoint.operations.forEach { operation -> visit(operation) }
+    endPoint.parameters.forEach { parameter -> visit(parameter.schema) }
+    endPoint.payloads.forEach { payload -> visit(payload.schema) }
+    endPoint.servers.forEach { server -> visit(server) }
+    endPoint.security.forEach { securityRequirement -> visit(securityRequirement) }
+  }
+
+  protected fun visit(operation: Operation) {
+    operation.request?.let { request -> visit(request) }
+    operation.requests.forEach { request -> visit(request) }
+    operation.responses.forEach { response -> visit(response) }
+    operation.security.forEach { securityRequirement -> visit(securityRequirement) }
+    operation.callbacks.forEach { callback -> visit(callback) }
+    operation.servers.forEach { server -> visit(server) }
+  }
+
+  protected fun visit(request: Request) {
+    request.uriParameters.forEach { param -> visit(param.schema) }
+    request.queryParameters.forEach { param -> visit(param.schema) }
+    request.cookieParameters.forEach { param -> visit(param.schema) }
+    request.headers.forEach { param -> visit(param.schema) }
+    request.payloads.forEach { payload -> visit(payload.schema) }
+    request.queryString?.let { queryString -> visit(queryString) }
+  }
+
+  protected fun visit(response: Response) {
+    response.headers.forEach { header -> visit(header.schema) }
+    response.payloads.forEach { payload -> visit(payload.schema) }
+    response.links.forEach { templatedLink -> visit(templatedLink) }
+  }
+
+  protected fun visit(templatedLink: TemplatedLink) {
+    templatedLink.server?.let { server -> visit(server) }
+  }
+
+  protected fun visit(callback: Callback) {
+    callback.endPoint?.let { endPoint -> visit(endPoint) }
+  }
+
+  protected fun visit(server: Server) {
+    server.variables.forEach { serverVar -> visit(serverVar.schema) }
+    server.security.forEach { securityRequirement -> visit(securityRequirement) }
+  }
+
+  protected fun visit(securityRequirement: SecurityRequirement) {
+    securityRequirement.schemes.forEach { parametrizedSecurityScheme -> visit(parametrizedSecurityScheme) }
+  }
+
+  protected fun visit(scheme: ParametrizedSecurityScheme) {
+    visit(scheme.scheme)
+  }
+
+  protected fun visit(scheme: SecurityScheme) {
+    scheme.headers?.forEach { header -> visit(header.schema) }
+    scheme.queryParameters?.forEach { header -> visit(header.schema) }
+    scheme.responses?.forEach { response -> visit(response) }
+    scheme.queryString?.let { queryString -> visit(queryString) }
+  }
+}

--- a/generator/src/main/kotlin/io/outfoxx/sunday/generator/utils/WebApiExts.kt
+++ b/generator/src/main/kotlin/io/outfoxx/sunday/generator/utils/WebApiExts.kt
@@ -18,76 +18,68 @@
 
 package io.outfoxx.sunday.generator.utils
 
-import amf.client.model.Annotable
-import amf.client.model.Annotations
-import amf.client.model.BoolField
-import amf.client.model.DoubleField
-import amf.client.model.IntField
-import amf.client.model.StrField
-import amf.client.model.document.BaseUnit
-import amf.client.model.document.DeclaresModel
-import amf.client.model.document.Document
-import amf.client.model.document.EncodesModel
-import amf.client.model.document.ExternalFragment
-import amf.client.model.domain.AnyShape
-import amf.client.model.domain.ArrayNode
-import amf.client.model.domain.ArrayShape
-import amf.client.model.domain.Callback
-import amf.client.model.domain.ChannelBindings
-import amf.client.model.domain.CorrelationId
-import amf.client.model.domain.CreativeWork
-import amf.client.model.domain.CustomDomainProperty
-import amf.client.model.domain.CustomizableElement
-import amf.client.model.domain.DataArrangeShape
-import amf.client.model.domain.DataNode
-import amf.client.model.domain.DomainElement
-import amf.client.model.domain.DomainExtension
-import amf.client.model.domain.Encoding
-import amf.client.model.domain.EndPoint
-import amf.client.model.domain.Example
-import amf.client.model.domain.IriTemplateMapping
-import amf.client.model.domain.License
-import amf.client.model.domain.Linkable
-import amf.client.model.domain.Message
-import amf.client.model.domain.MessageBindings
-import amf.client.model.domain.NamedDomainElement
-import amf.client.model.domain.NilShape
-import amf.client.model.domain.NodeShape
-import amf.client.model.domain.ObjectNode
-import amf.client.model.domain.Operation
-import amf.client.model.domain.OperationBindings
-import amf.client.model.domain.Organization
-import amf.client.model.domain.Parameter
-import amf.client.model.domain.ParametrizedSecurityScheme
-import amf.client.model.domain.Payload
-import amf.client.model.domain.PropertyDependencies
-import amf.client.model.domain.PropertyShape
-import amf.client.model.domain.Request
-import amf.client.model.domain.Response
-import amf.client.model.domain.ScalarNode
-import amf.client.model.domain.ScalarShape
-import amf.client.model.domain.SecurityRequirement
-import amf.client.model.domain.SecurityScheme
-import amf.client.model.domain.Server
-import amf.client.model.domain.ServerBindings
-import amf.client.model.domain.Settings
-import amf.client.model.domain.Shape
-import amf.client.model.domain.ShapeExtension
-import amf.client.model.domain.Tag
-import amf.client.model.domain.TemplatedLink
-import amf.client.model.domain.UnionShape
-import amf.client.model.domain.WebApi
-import amf.client.model.domain.XMLSerializer
-import amf.core.annotations.Aliases
-import amf.core.model.DataType
-import amf.core.remote.Vendor
-import amf.plugins.document.webapi.annotations.ExternalJsonSchemaShape
+import amf.apicontract.client.platform.model.domain.Callback
+import amf.apicontract.client.platform.model.domain.CorrelationId
+import amf.apicontract.client.platform.model.domain.Encoding
+import amf.apicontract.client.platform.model.domain.EndPoint
+import amf.apicontract.client.platform.model.domain.License
+import amf.apicontract.client.platform.model.domain.Message
+import amf.apicontract.client.platform.model.domain.Operation
+import amf.apicontract.client.platform.model.domain.Organization
+import amf.apicontract.client.platform.model.domain.Parameter
+import amf.apicontract.client.platform.model.domain.Payload
+import amf.apicontract.client.platform.model.domain.Request
+import amf.apicontract.client.platform.model.domain.Response
+import amf.apicontract.client.platform.model.domain.Server
+import amf.apicontract.client.platform.model.domain.Tag
+import amf.apicontract.client.platform.model.domain.TemplatedLink
+import amf.apicontract.client.platform.model.domain.api.WebApi
+import amf.apicontract.client.platform.model.domain.bindings.ChannelBindings
+import amf.apicontract.client.platform.model.domain.bindings.MessageBindings
+import amf.apicontract.client.platform.model.domain.bindings.OperationBindings
+import amf.apicontract.client.platform.model.domain.bindings.ServerBindings
+import amf.apicontract.client.platform.model.domain.security.ParametrizedSecurityScheme
+import amf.apicontract.client.platform.model.domain.security.SecurityRequirement
+import amf.apicontract.client.platform.model.domain.security.SecurityScheme
+import amf.apicontract.client.platform.model.domain.security.Settings
+import amf.core.client.platform.model.Annotable
+import amf.core.client.platform.model.Annotations
+import amf.core.client.platform.model.BoolField
+import amf.core.client.platform.model.DataTypes
+import amf.core.client.platform.model.DoubleField
+import amf.core.client.platform.model.IntField
+import amf.core.client.platform.model.StrField
+import amf.core.client.platform.model.document.BaseUnit
+import amf.core.client.platform.model.document.DeclaresModel
+import amf.core.client.platform.model.document.Document
+import amf.core.client.platform.model.document.EncodesModel
+import amf.core.client.platform.model.domain.ArrayNode
+import amf.core.client.platform.model.domain.CustomDomainProperty
+import amf.core.client.platform.model.domain.CustomizableElement
+import amf.core.client.platform.model.domain.DataNode
+import amf.core.client.platform.model.domain.DomainElement
+import amf.core.client.platform.model.domain.DomainExtension
+import amf.core.client.platform.model.domain.Linkable
+import amf.core.client.platform.model.domain.NamedDomainElement
+import amf.core.client.platform.model.domain.ObjectNode
+import amf.core.client.platform.model.domain.PropertyShape
+import amf.core.client.platform.model.domain.ScalarNode
+import amf.core.client.platform.model.domain.Shape
+import amf.core.client.platform.model.domain.ShapeExtension
+import amf.shapes.client.platform.model.domain.AnyShape
+import amf.shapes.client.platform.model.domain.ArrayShape
+import amf.shapes.client.platform.model.domain.CreativeWork
+import amf.shapes.client.platform.model.domain.DataArrangeShape
+import amf.shapes.client.platform.model.domain.Example
+import amf.shapes.client.platform.model.domain.IriTemplateMapping
+import amf.shapes.client.platform.model.domain.NilShape
+import amf.shapes.client.platform.model.domain.NodeShape
+import amf.shapes.client.platform.model.domain.PropertyDependencies
+import amf.shapes.client.platform.model.domain.ScalarShape
+import amf.shapes.client.platform.model.domain.UnionShape
+import amf.shapes.client.platform.model.domain.XMLSerializer
 import io.outfoxx.sunday.generator.APIAnnotationName
 import io.outfoxx.sunday.generator.GenerationMode
-import org.apache.http.client.utils.URIBuilder
-import scala.collection.JavaConverters
-import java.net.URI
-import java.time.Duration
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
@@ -107,88 +99,6 @@ val BaseUnit.id: String get() = this.id()
 val BaseUnit.references: List<BaseUnit> get() = this.references()
 val BaseUnit.location: String get() = this.location()
 val BaseUnit.usage: String? get() = this.usage().value
-val BaseUnit.modelVersion: String? get() = this.modelVersion().value
-val BaseUnit.sourceVendor: Vendor? get() = this.sourceVendor().orElse(null)
-
-fun BaseUnit.findDeclaringUnit(element: DomainElement) = allUnits.first { it.location == element.annotations.location }
-
-fun BaseUnit.findImportingUnit(element: DomainElement, allUnits: List<BaseUnit>): BaseUnit? {
-  if (this !is ExternalFragment) return null
-
-  val importingUnitLocation = element.id.split("#", limit = 2).first()
-  return allUnits.find { it.location == importingUnitLocation }
-}
-
-fun BaseUnit.findInheritingShapes(type: Shape): List<Shape> {
-  val resolvedType = type.resolve
-  return allUnits.filterIsInstance<DeclaresModel>()
-    .flatMap { unit ->
-      unit.declares.filterIsInstance<NodeShape>()
-        .filter { declared ->
-          declared.inherits.any { inherit ->
-            inherit.id == resolvedType.id || (inherit.linkTarget?.id == resolvedType.id)
-          }
-        }
-        .plus(
-          unit.declares.filterIsInstance<Shape>()
-            .filter { declared ->
-              declared.inheritsViaAggregation && declared.aggregateInheritanceSuper.resolve.id == resolvedType.id
-            }
-        )
-    }
-}
-
-private val ELEMENT_REF_REGEX = """(?:([^.]+)\.)?([\w-_.]+)""".toRegex()
-
-fun BaseUnit.resolveRef(ref: String): Pair<DomainElement, BaseUnit>? =
-  if (ref.contains('#')) {
-    resolveJsonRef(ref)
-  } else {
-    resolveUsesRef(ref)
-  }
-
-fun BaseUnit.resolveJsonRef(ref: String): Pair<DomainElement, BaseUnit>? {
-  val refUri = URI(location).resolve(ref)
-  val refLocation = URIBuilder(refUri).setFragment(null).build()
-  val refName = refUri.fragment.split('/').last()
-
-  val refDeclaringUnit = allUnits.first { URI(it.location()) == refLocation }
-  val refElement =
-    (refDeclaringUnit as DeclaresModel).declares
-      .filterIsInstance<NamedDomainElement>()
-      .find { it.name == refName } as? DomainElement ?: return null
-
-  return refElement to refDeclaringUnit
-}
-
-fun BaseUnit.resolveUsesRef(name: String): Pair<DomainElement, BaseUnit>? {
-
-  val (libraryName, declarationName) =
-    ELEMENT_REF_REGEX.matchEntire(name)?.destructured
-      ?: error("Invalid reference '$name'")
-
-  val declarationUnit =
-    if (libraryName.isBlank()) {
-
-      this as? DeclaresModel
-    } else {
-
-      val aliases: Aliases =
-        annotations._internal().find(Aliases::class.java).getOrElse(null)
-          ?: error("Unable to find unit aliases")
-
-      val unitUrl = JavaConverters.setAsJavaSet(aliases.aliases()).first { it._1 == libraryName }?._2?._1
-
-      allUnits.find { it.location == unitUrl } as? DeclaresModel
-    } ?: return null
-
-  val decl = declarationUnit.declares
-    .filterIsInstance<NamedDomainElement>()
-    .firstOrNull { it.name == declarationName } as? DomainElement
-    ?: return null
-
-  return decl to (declarationUnit as BaseUnit)
-}
 
 //
 val DeclaresModel.declares: List<DomainElement> get() = this.declares()
@@ -229,7 +139,7 @@ fun CustomizableElement.findBoolAnnotation(name: APIAnnotationName, generationMo
 fun CustomizableElement.findIntAnnotation(name: APIAnnotationName, generationMode: GenerationMode?) =
   findAnnotation(name, generationMode)?.rawScalarValue?.toInt()
 
-fun CustomizableElement.findArrayAnnotation(name: APIAnnotationName, generationMode: GenerationMode?) =
+fun CustomizableElement.findArrayAnnotation(name: APIAnnotationName, generationMode: GenerationMode?): List<DataNode>? =
   findAnnotation(name, generationMode)?.let { it as ArrayNode }?.members()
 
 //
@@ -362,6 +272,10 @@ val Response.statusCode: String get() = this.statusCode().value()
 val Response.headers: List<Parameter> get() = this.headers()
 val Response.links: List<TemplatedLink> get() = this.links()
 
+val Callback.name: String? get() = this.name().value
+val Callback.expression: String? get() = this.expression().value
+val Callback.endPoint: EndPoint? get() = this.endpoint()
+
 //
 val Payload.mediaType: String? get() = this.mediaType().value
 val Payload.schemaMediaType: String? get() = this.schemaMediaType().value
@@ -413,44 +327,6 @@ val Shape.thenShape: Shape? get() = this.thenShape()
 val Shape.elseShape: Shape? get() = this.elseShape()
 val Shape.inlined: Boolean get() = this.annotations.inlinedElement()
 
-val Shape.wasLink: Boolean get() = this.annotations._internal().contains(ExternalJsonSchemaShape::class.java)
-val Shape.isOrWasLink: Boolean get() = isLink || wasLink
-
-val Shape.resolve: Shape
-  get() =
-    if (this.isLink)
-      (this.linkTarget as Shape).resolve
-    else if (this.inherits.size == 1 && (this !is NodeShape || this.isReferenceNode))
-      this.inherits.first().resolve
-    else
-      this
-
-val Shape.inheritsViaAggregation: Boolean get() = and.size == 2 && and.count { it is NodeShape && !it.isOrWasLink } == 1 && and.count { it.isOrWasLink } == 1
-val Shape.aggregateInheritanceSuper: Shape get() = and.first { it.isOrWasLink }.resolve
-val Shape.aggregateInheritanceNode: NodeShape get() = and.filterIsInstance<NodeShape>().first { !it.isOrWasLink }
-
-val Shape.inheritsViaInherits: Boolean get() = inherits.size == 1 && inherits.first() is NodeShape
-val Shape.inheritsInheritanceSuper: Shape get() = inherits.first().resolve
-val Shape.inheritsInheritanceNode: NodeShape get() = this as NodeShape
-
-val Shape.anyInheritance: Boolean get() = inheritsViaAggregation || inheritsViaInherits
-val Shape.anyInheritanceSuper: Shape?
-  get() =
-    when {
-      inheritsViaAggregation -> aggregateInheritanceSuper
-      inheritsViaInherits -> inheritsInheritanceSuper
-      else -> null
-    }
-val Shape.anyInheritanceNode: NodeShape?
-  get() =
-    when {
-      inheritsViaAggregation -> aggregateInheritanceNode
-      inheritsViaInherits -> inheritsInheritanceNode
-      else -> null
-    }
-
-val Shape.inheritanceRoot: Shape get() = anyInheritanceSuper?.inheritanceRoot ?: this
-
 //
 val ShapeExtension.definedBy: PropertyShape get() = this.definedBy()
 val ShapeExtension.extension: DataNode? get() = this.extension()
@@ -493,23 +369,18 @@ val NodeShape.additionalPropertiesSchema: Shape? get() = this.additionalProperti
 val NodeShape.dependencies: List<PropertyDependencies> get() = this.dependencies()
 val NodeShape.propertyNames: Shape? get() = this.propertyNames()
 
-val NodeShape.properties: List<PropertyShape> get() =
+val NodeShape.properties: List<PropertyShape> get() = this.properties()
+
+val NodeShape.nonPatternProperties: List<PropertyShape> get() =
   this.properties().filter { it.patternName == null }
 
-val NodeShape.isReferenceNode: Boolean get() =
-  inherits.size == 1 && dependencies.isEmpty() &&
-    properties.isEmpty() && propertyNames == null &&
-    additionalPropertiesSchema == null && minProperties == null && maxProperties == null &&
-    discriminator == null && discriminatorValue == null && discriminatorMapping.isEmpty() &&
-    or.isEmpty() && and.isEmpty() && xone.isEmpty() && not == null &&
-    ifShape == null && elseShape == null && thenShape == null
+val NodeShape.patternProperties: List<PropertyShape> get() =
+  this.properties().filterNot { it.patternName == null }
 
 //
 val DataArrangeShape.minItems: Int? get() = this.minItems().value
 val DataArrangeShape.maxItems: Int? get() = this.maxItems().value
-val DataArrangeShape.uniqueItems: Boolean?
-  get() =
-    this.uniqueItems().value
+val DataArrangeShape.uniqueItems: Boolean? get() = this.uniqueItems().value
 
 //
 val ArrayShape.items: Shape? get() = this.items()
@@ -529,27 +400,28 @@ val PropertyShape.maxCount: Int? get() = this.maxCount().value
 val PropertyShape.patternName: String? get() = this.patternName().value
 val PropertyShape.optional: Boolean get() = (this.minCount ?: 0) == 0
 val PropertyShape.required: Boolean get() = (this.minCount ?: 0) > 0
-val PropertyShape.nullable: Boolean get() = (range.resolve as? UnionShape)?.makesNullable ?: false
+val PropertyShape.nullable: Boolean get() = (range as? UnionShape)?.makesNullable ?: false
+val PropertyShape.isInherited: Boolean get() = annotations.inheritanceProvenance().isPresent
 
 //
 val DataNode.anyValue: Any? get() =
   when (this) {
     is ScalarNode ->
       when (dataType().value()) {
-        DataType.String() -> value().value
-        DataType.Boolean() -> value().value?.toBoolean()
-        DataType.Integer() -> value().value?.toInt()
-        DataType.Long() -> value().value?.toLong()
-        DataType.Float() -> value().value?.toFloat()
-        DataType.Double() -> value().value?.toDouble()
-        DataType.Number() -> value().value?.toBigDecimal()
-        DataType.Decimal() -> value().value?.toBigDecimal()
-        DataType.Duration() -> value().value?.let { Duration.parse(it) }
-        DataType.Date() -> value().value?.let { LocalDate.parse(it) }
-        DataType.Time() -> value().value?.let { LocalTime.parse(it) }
-        DataType.DateTimeOnly() -> value().value?.let { LocalDateTime.parse(it) }
-        DataType.DateTime() -> value().value?.let { OffsetDateTime.parse(it) }
-        DataType.Binary() -> value().value?.let { Base64.getDecoder().decode(it) }
+        DataTypes.String() -> value().value
+        DataTypes.Boolean() -> value().value?.toBoolean()
+        DataTypes.Integer() -> value().value?.toInt()
+        DataTypes.Long() -> value().value?.toLong()
+        DataTypes.Float() -> value().value?.toFloat()
+        DataTypes.Double() -> value().value?.toDouble()
+        DataTypes.Number() -> value().value?.toBigDecimal()
+        DataTypes.Decimal() -> value().value?.toBigDecimal()
+//        DataTypes.Duration() -> value().value?.let { Duration.parse(it) }
+        DataTypes.Date() -> value().value?.let { LocalDate.parse(it) }
+        DataTypes.Time() -> value().value?.let { LocalTime.parse(it) }
+        DataTypes.DateTimeOnly() -> value().value?.let { LocalDateTime.parse(it) }
+        DataTypes.DateTime() -> value().value?.let { OffsetDateTime.parse(it) }
+        DataTypes.Binary() -> value().value?.let { Base64.getDecoder().decode(it) }
         else -> error("unsupported scalar node data type")
       }
     is ArrayNode -> arrayValue!!
@@ -562,20 +434,20 @@ val DataNode.numberValue: Number? get() = anyValue as? Number
 val DataNode.rawScalarValue: String? get() = (this as? ScalarNode)?.value
 val DataNode.scalarValue: Any? get() = (this as? ScalarNode)?.value?.let {
   when (dataType().value()) {
-    DataType.String() -> value().value
-    DataType.Boolean() -> value().value?.toBoolean()
-    DataType.Integer() -> value().value?.toInt()
-    DataType.Long() -> value().value?.toLong()
-    DataType.Float() -> value().value?.toFloat()
-    DataType.Double() -> value().value?.toDouble()
-    DataType.Number() -> value().value?.toBigDecimal()
-    DataType.Decimal() -> value().value?.toBigDecimal()
-    DataType.Duration() -> value().value?.let { Duration.parse(it) }
-    DataType.Date() -> value().value?.let { LocalDate.parse(it) }
-    DataType.Time() -> value().value?.let { LocalTime.parse(it) }
-    DataType.DateTimeOnly() -> value().value?.let { LocalDateTime.parse(it) }
-    DataType.DateTime() -> value().value?.let { OffsetDateTime.parse(it) }
-    DataType.Binary() -> value().value?.let { Base64.getDecoder().decode(it) }
+    DataTypes.String() -> value().value
+    DataTypes.Boolean() -> value().value?.toBoolean()
+    DataTypes.Integer() -> value().value?.toInt()
+    DataTypes.Long() -> value().value?.toLong()
+    DataTypes.Float() -> value().value?.toFloat()
+    DataTypes.Double() -> value().value?.toDouble()
+    DataTypes.Number() -> value().value?.toBigDecimal()
+    DataTypes.Decimal() -> value().value?.toBigDecimal()
+//    DataTypes.Duration() -> value().value?.let { Duration.parse(it) }
+    DataTypes.Date() -> value().value?.let { LocalDate.parse(it) }
+    DataTypes.Time() -> value().value?.let { LocalTime.parse(it) }
+    DataTypes.DateTimeOnly() -> value().value?.let { LocalDateTime.parse(it) }
+    DataTypes.DateTime() -> value().value?.let { OffsetDateTime.parse(it) }
+    DataTypes.Binary() -> value().value?.let { Base64.getDecoder().decode(it) }
     else -> error("unsupported scalar node data type")
   }
 }

--- a/generator/src/test/kotlin/io/outfoxx/sunday/annotation/Generated.kt
+++ b/generator/src/test/kotlin/io/outfoxx/sunday/annotation/Generated.kt
@@ -14,27 +14,9 @@
  * limitations under the License.
  */
 
-package io.outfoxx.sunday.generator
+package io.outfoxx.sunday.annotation
 
-import amf.core.client.platform.model.domain.DomainElement
-import io.outfoxx.sunday.generator.utils.location
-
-class GenerationException(
-  message: String,
-  val file: String,
-  val line: Int,
-  val column: Int
-) : Exception(message)
-
-fun genError(message: String, element: DomainElement? = null): Nothing {
-  if (element == null) {
-    throw GenerationException(message, "", 0, 0)
-  }
-
-  throw GenerationException(
-    message,
-    element.annotations().location,
-    element.position().start().line(),
-    element.position().start().column()
-  )
-}
+annotation class Generated(
+  val value: Array<String>,
+  val date: String,
+)

--- a/generator/src/test/kotlin/io/outfoxx/sunday/generator/RamlProcessTest.kt
+++ b/generator/src/test/kotlin/io/outfoxx/sunday/generator/RamlProcessTest.kt
@@ -20,7 +20,11 @@ import io.outfoxx.sunday.generator.common.APIProcessor
 import io.outfoxx.sunday.generator.common.APIProcessor.Result.Level
 import io.outfoxx.sunday.generator.utils.TestAPIProcessing
 import io.outfoxx.sunday.generator.utils.api
+import io.outfoxx.sunday.generator.utils.customDomainProperties
 import io.outfoxx.sunday.generator.utils.endPoints
+import io.outfoxx.sunday.generator.utils.method
+import io.outfoxx.sunday.generator.utils.name
+import io.outfoxx.sunday.generator.utils.operations
 import io.outfoxx.sunday.generator.utils.path
 import io.outfoxx.sunday.test.extensions.ResourceExtension
 import io.outfoxx.sunday.test.extensions.ResourceUri
@@ -29,9 +33,10 @@ import org.hamcrest.Matchers.blankOrNullString
 import org.hamcrest.Matchers.containsInAnyOrder
 import org.hamcrest.Matchers.empty
 import org.hamcrest.Matchers.equalTo
+import org.hamcrest.Matchers.hasItem
 import org.hamcrest.Matchers.hasSize
 import org.hamcrest.Matchers.not
-import org.junit.jupiter.api.Disabled
+import org.hamcrest.Matchers.notNullValue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import java.net.URI
@@ -53,7 +58,6 @@ class RamlProcessTest {
   }
 
   @Test
-  @Disabled("https://github.com/aml-org/amf/issues/962")
   fun `process produces valid overlays documents`(
     @ResourceUri("raml/test-overlay.raml") testUri: URI
   ) {
@@ -62,6 +66,11 @@ class RamlProcessTest {
 
     assertThat(result.isValid, equalTo(true))
     assertThat(result.validationLog, empty())
-    assertThat(result.document.api.endPoints.map { it.path }, containsInAnyOrder("/test", "/test/{id}"))
+    assertThat(result.document.api.endPoints.map { it.path }, containsInAnyOrder("/test", "/test/{id}", "/test2", "/test2/{id}"))
+
+    val testIdEndPoint = result.document.api.endPoints.first { it.path == "/test/{id}" }
+    val getOperation = testIdEndPoint.operations.firstOrNull { it.method == "get" }
+    assertThat(getOperation, notNullValue())
+    assertThat(getOperation?.customDomainProperties?.map { it.name }, hasItem("test-ann"))
   }
 }

--- a/generator/src/test/kotlin/io/outfoxx/sunday/generator/kotlin/RamlGeneratedAnnotationsTest.kt
+++ b/generator/src/test/kotlin/io/outfoxx/sunday/generator/kotlin/RamlGeneratedAnnotationsTest.kt
@@ -72,14 +72,14 @@ class RamlGeneratedAnnotationsTest {
     @ResourceUri("raml/type-gen/general/generated-annotations.raml") testUri: URI
   ) {
 
-    val typeRegistry = KotlinTypeRegistry("io.test", "javax.annotation.Generated", GenerationMode.Server, setOf(AddGeneratedAnnotation))
+    val typeRegistry = KotlinTypeRegistry("io.test", "io.outfoxx.sunday.annotation.Generated", GenerationMode.Server, setOf(AddGeneratedAnnotation))
 
     val type = findType("io.test.Test", generateTypes(testUri, typeRegistry))
     assertEquals(
       """
         package io.test.service
         
-        import javax.`annotation`.Generated
+        import io.outfoxx.sunday.`annotation`.Generated
         import kotlin.String
         
         @Generated(
@@ -134,9 +134,10 @@ class RamlGeneratedAnnotationsTest {
     val typeRegistry = KotlinTypeRegistry("io.test", null, GenerationMode.Server, setOf(AddGeneratedAnnotation))
 
     val builtTypes =
-      generate(testUri, typeRegistry) { document ->
+      generate(testUri, typeRegistry) { document, shapeIndex ->
         KotlinJAXRSGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           kotlinJAXRSTestOptions
         )
@@ -184,9 +185,10 @@ class RamlGeneratedAnnotationsTest {
     val typeRegistry = KotlinTypeRegistry("io.test", null, GenerationMode.Server, setOf(SuppressPublicApiWarnings))
 
     val builtTypes =
-      generate(testUri, typeRegistry) { document ->
+      generate(testUri, typeRegistry) { document, shapeIndex ->
         KotlinJAXRSGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           kotlinJAXRSTestOptions,
         )

--- a/generator/src/test/kotlin/io/outfoxx/sunday/generator/kotlin/jaxrs/BaseUriTest.kt
+++ b/generator/src/test/kotlin/io/outfoxx/sunday/generator/kotlin/jaxrs/BaseUriTest.kt
@@ -45,9 +45,10 @@ class BaseUriTest {
     val typeRegistry = KotlinTypeRegistry("io.test", null, Client, setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry) { document ->
+      generate(testUri, typeRegistry) { document, shapeIndex ->
         KotlinJAXRSGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           kotlinJAXRSTestOptions,
         )
@@ -93,9 +94,10 @@ class BaseUriTest {
     val typeRegistry = KotlinTypeRegistry("io.test", null, Server, setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry) { document ->
+      generate(testUri, typeRegistry) { document, shapeIndex ->
         KotlinJAXRSGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           kotlinJAXRSTestOptions,
         )

--- a/generator/src/test/kotlin/io/outfoxx/sunday/generator/kotlin/jaxrs/RequestBodyParamTest.kt
+++ b/generator/src/test/kotlin/io/outfoxx/sunday/generator/kotlin/jaxrs/RequestBodyParamTest.kt
@@ -43,9 +43,10 @@ class RequestBodyParamTest {
     val typeRegistry = KotlinTypeRegistry("io.test", null, GenerationMode.Server, setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry) { document ->
+      generate(testUri, typeRegistry) { document, shapeIndex ->
         KotlinJAXRSGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           kotlinJAXRSTestOptions,
         )
@@ -88,9 +89,10 @@ class RequestBodyParamTest {
     val typeRegistry = KotlinTypeRegistry("io.test", null, GenerationMode.Server, setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry) { document ->
+      generate(testUri, typeRegistry) { document, shapeIndex ->
         KotlinJAXRSGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           kotlinJAXRSTestOptions,
         )
@@ -142,9 +144,10 @@ class RequestBodyParamTest {
     val typeRegistry = KotlinTypeRegistry("io.test", null, GenerationMode.Client, setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry) { document ->
+      generate(testUri, typeRegistry) { document, shapeIndex ->
         KotlinJAXRSGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           kotlinJAXRSTestOptions,
         )
@@ -195,9 +198,10 @@ class RequestBodyParamTest {
     val typeRegistry = KotlinTypeRegistry("io.test", null, GenerationMode.Server, setOf(ValidationConstraints))
 
     val builtTypes =
-      generate(testUri, typeRegistry) { document ->
+      generate(testUri, typeRegistry) { document, shapeIndex ->
         KotlinJAXRSGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           kotlinJAXRSTestOptions,
         )
@@ -241,9 +245,10 @@ class RequestBodyParamTest {
     val typeRegistry = KotlinTypeRegistry("io.test", null, GenerationMode.Server, setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry) { document ->
+      generate(testUri, typeRegistry) { document, shapeIndex ->
         KotlinJAXRSGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           kotlinJAXRSTestOptions,
         )
@@ -286,9 +291,10 @@ class RequestBodyParamTest {
     val typeRegistry = KotlinTypeRegistry("io.test", null, GenerationMode.Server, setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry) { document ->
+      generate(testUri, typeRegistry) { document, shapeIndex ->
         KotlinJAXRSGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           kotlinJAXRSTestOptions,
         )

--- a/generator/src/test/kotlin/io/outfoxx/sunday/generator/kotlin/jaxrs/RequestCoroutineMethodsTest.kt
+++ b/generator/src/test/kotlin/io/outfoxx/sunday/generator/kotlin/jaxrs/RequestCoroutineMethodsTest.kt
@@ -42,9 +42,10 @@ class RequestCoroutineMethodsTest {
     val typeRegistry = KotlinTypeRegistry("io.test", null, GenerationMode.Server, setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry) { document ->
+      generate(testUri, typeRegistry) { document, shapeIndex ->
         KotlinJAXRSGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           KotlinJAXRSGenerator.Options(
             true,
@@ -96,9 +97,10 @@ class RequestCoroutineMethodsTest {
     val typeRegistry = KotlinTypeRegistry("io.test", null, GenerationMode.Client, setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry) { document ->
+      generate(testUri, typeRegistry) { document, shapeIndex ->
         KotlinJAXRSGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           KotlinJAXRSGenerator.Options(
             true,
@@ -150,9 +152,10 @@ class RequestCoroutineMethodsTest {
     val typeRegistry = KotlinTypeRegistry("io.test", null, GenerationMode.Client, setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry) { document ->
+      generate(testUri, typeRegistry) { document, shapeIndex ->
         KotlinJAXRSGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           KotlinJAXRSGenerator.Options(
             true,
@@ -220,9 +223,10 @@ class RequestCoroutineMethodsTest {
     val typeRegistry = KotlinTypeRegistry("io.test", null, GenerationMode.Server, setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry) { document ->
+      generate(testUri, typeRegistry) { document, shapeIndex ->
         KotlinJAXRSGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           KotlinJAXRSGenerator.Options(
             true,
@@ -282,9 +286,10 @@ class RequestCoroutineMethodsTest {
     val typeRegistry = KotlinTypeRegistry("io.test", null, GenerationMode.Client, setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry) { document ->
+      generate(testUri, typeRegistry) { document, shapeIndex ->
         KotlinJAXRSGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           KotlinJAXRSGenerator.Options(
             true,
@@ -344,9 +349,10 @@ class RequestCoroutineMethodsTest {
     val typeRegistry = KotlinTypeRegistry("io.test", null, GenerationMode.Server, setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry) { document ->
+      generate(testUri, typeRegistry) { document, shapeIndex ->
         KotlinJAXRSGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           KotlinJAXRSGenerator.Options(
             true,
@@ -405,9 +411,10 @@ class RequestCoroutineMethodsTest {
     val typeRegistry = KotlinTypeRegistry("io.test", null, GenerationMode.Client, setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry) { document ->
+      generate(testUri, typeRegistry) { document, shapeIndex ->
         KotlinJAXRSGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           KotlinJAXRSGenerator.Options(
             true,

--- a/generator/src/test/kotlin/io/outfoxx/sunday/generator/kotlin/jaxrs/RequestExplicitSecurityParamsTest.kt
+++ b/generator/src/test/kotlin/io/outfoxx/sunday/generator/kotlin/jaxrs/RequestExplicitSecurityParamsTest.kt
@@ -58,9 +58,10 @@ class RequestExplicitSecurityParamsTest {
     val typeRegistry = KotlinTypeRegistry("io.test", null, GenerationMode.Server, setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry) { document ->
+      generate(testUri, typeRegistry) { document, shapeIndex ->
         KotlinJAXRSGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           kotlinJAXRSTestOptions,
         )

--- a/generator/src/test/kotlin/io/outfoxx/sunday/generator/kotlin/jaxrs/RequestHeaderParamsTest.kt
+++ b/generator/src/test/kotlin/io/outfoxx/sunday/generator/kotlin/jaxrs/RequestHeaderParamsTest.kt
@@ -43,9 +43,10 @@ class RequestHeaderParamsTest {
     val typeRegistry = KotlinTypeRegistry("io.test", null, GenerationMode.Server, setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry) { document ->
+      generate(testUri, typeRegistry) { document, shapeIndex ->
         KotlinJAXRSGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           kotlinJAXRSTestOptions,
         )
@@ -96,9 +97,10 @@ class RequestHeaderParamsTest {
     val typeRegistry = KotlinTypeRegistry("io.test", null, GenerationMode.Server, setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry) { document ->
+      generate(testUri, typeRegistry) { document, shapeIndex ->
         KotlinJAXRSGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           kotlinJAXRSTestOptions,
         )
@@ -151,9 +153,10 @@ class RequestHeaderParamsTest {
     val typeRegistry = KotlinTypeRegistry("io.test", null, GenerationMode.Server, setOf(ValidationConstraints))
 
     val builtTypes =
-      generate(testUri, typeRegistry) { document ->
+      generate(testUri, typeRegistry) { document, shapeIndex ->
         KotlinJAXRSGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           kotlinJAXRSTestOptions,
         )
@@ -207,9 +210,10 @@ class RequestHeaderParamsTest {
     val typeRegistry = KotlinTypeRegistry("io.test", null, GenerationMode.Server, setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry) { document ->
+      generate(testUri, typeRegistry) { document, shapeIndex ->
         KotlinJAXRSGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           kotlinJAXRSTestOptions,
         )

--- a/generator/src/test/kotlin/io/outfoxx/sunday/generator/kotlin/jaxrs/RequestMethodsTest.kt
+++ b/generator/src/test/kotlin/io/outfoxx/sunday/generator/kotlin/jaxrs/RequestMethodsTest.kt
@@ -42,9 +42,10 @@ class RequestMethodsTest {
     val typeRegistry = KotlinTypeRegistry("io.test", null, GenerationMode.Server, setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry) { document ->
+      generate(testUri, typeRegistry) { document, shapeIndex ->
         KotlinJAXRSGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           kotlinJAXRSTestOptions,
         )
@@ -122,9 +123,10 @@ class RequestMethodsTest {
     val typeRegistry = KotlinTypeRegistry("io.test", null, GenerationMode.Client, setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry) { document ->
+      generate(testUri, typeRegistry) { document, shapeIndex ->
         KotlinJAXRSGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           kotlinJAXRSTestOptions,
         )
@@ -200,9 +202,10 @@ class RequestMethodsTest {
     val typeRegistry = KotlinTypeRegistry("io.test", null, GenerationMode.Client, setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry) { document ->
+      generate(testUri, typeRegistry) { document, shapeIndex ->
         KotlinJAXRSGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           kotlinJAXRSTestOptions,
         )

--- a/generator/src/test/kotlin/io/outfoxx/sunday/generator/kotlin/jaxrs/RequestMixedParamsTest.kt
+++ b/generator/src/test/kotlin/io/outfoxx/sunday/generator/kotlin/jaxrs/RequestMixedParamsTest.kt
@@ -42,9 +42,10 @@ class RequestMixedParamsTest {
     val typeRegistry = KotlinTypeRegistry("io.test", null, GenerationMode.Server, setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry) { document ->
+      generate(testUri, typeRegistry) { document, shapeIndex ->
         KotlinJAXRSGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           kotlinJAXRSTestOptions,
         )
@@ -108,9 +109,10 @@ class RequestMixedParamsTest {
     val typeRegistry = KotlinTypeRegistry("io.test", null, GenerationMode.Server, setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry) { document ->
+      generate(testUri, typeRegistry) { document, shapeIndex ->
         KotlinJAXRSGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           kotlinJAXRSTestOptions,
         )

--- a/generator/src/test/kotlin/io/outfoxx/sunday/generator/kotlin/jaxrs/RequestQueryParamsTest.kt
+++ b/generator/src/test/kotlin/io/outfoxx/sunday/generator/kotlin/jaxrs/RequestQueryParamsTest.kt
@@ -43,9 +43,10 @@ class RequestQueryParamsTest {
     val typeRegistry = KotlinTypeRegistry("io.test", null, GenerationMode.Server, setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry) { document ->
+      generate(testUri, typeRegistry) { document, shapeIndex ->
         KotlinJAXRSGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           kotlinJAXRSTestOptions,
         )
@@ -96,9 +97,10 @@ class RequestQueryParamsTest {
     val typeRegistry = KotlinTypeRegistry("io.test", null, GenerationMode.Server, setOf(ValidationConstraints))
 
     val builtTypes =
-      generate(testUri, typeRegistry) { document ->
+      generate(testUri, typeRegistry) { document, shapeIndex ->
         KotlinJAXRSGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           kotlinJAXRSTestOptions,
         )
@@ -150,9 +152,10 @@ class RequestQueryParamsTest {
     val typeRegistry = KotlinTypeRegistry("io.test", null, GenerationMode.Server, setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry) { document ->
+      generate(testUri, typeRegistry) { document, shapeIndex ->
         KotlinJAXRSGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           kotlinJAXRSTestOptions,
         )
@@ -205,9 +208,10 @@ class RequestQueryParamsTest {
     val typeRegistry = KotlinTypeRegistry("io.test", null, GenerationMode.Server, setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry) { document ->
+      generate(testUri, typeRegistry) { document, shapeIndex ->
         KotlinJAXRSGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           kotlinJAXRSTestOptions,
         )

--- a/generator/src/test/kotlin/io/outfoxx/sunday/generator/kotlin/jaxrs/RequestReactiveMethodsTest.kt
+++ b/generator/src/test/kotlin/io/outfoxx/sunday/generator/kotlin/jaxrs/RequestReactiveMethodsTest.kt
@@ -48,9 +48,10 @@ class RequestReactiveMethodsTest {
     val typeRegistry = KotlinTypeRegistry("io.test", null, GenerationMode.Server, setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry) { document ->
+      generate(testUri, typeRegistry) { document, shapeIndex ->
         KotlinJAXRSGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           KotlinJAXRSGenerator.Options(
             false,
@@ -103,9 +104,10 @@ class RequestReactiveMethodsTest {
     val typeRegistry = KotlinTypeRegistry("io.test", null, GenerationMode.Client, setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry) { document ->
+      generate(testUri, typeRegistry) { document, shapeIndex ->
         KotlinJAXRSGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           KotlinJAXRSGenerator.Options(
             false,
@@ -158,9 +160,10 @@ class RequestReactiveMethodsTest {
     val typeRegistry = KotlinTypeRegistry("io.test", null, GenerationMode.Client, setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry) { document ->
+      generate(testUri, typeRegistry) { document, shapeIndex ->
         KotlinJAXRSGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           KotlinJAXRSGenerator.Options(
             false,
@@ -229,9 +232,10 @@ class RequestReactiveMethodsTest {
     val typeRegistry = KotlinTypeRegistry("io.test", null, GenerationMode.Client, setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry) { document ->
+      generate(testUri, typeRegistry) { document, shapeIndex ->
         KotlinJAXRSGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           KotlinJAXRSGenerator.Options(
             false,
@@ -300,9 +304,10 @@ class RequestReactiveMethodsTest {
     val typeRegistry = KotlinTypeRegistry("io.test", null, GenerationMode.Client, setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry) { document ->
+      generate(testUri, typeRegistry) { document, shapeIndex ->
         KotlinJAXRSGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           KotlinJAXRSGenerator.Options(
             false,
@@ -373,9 +378,10 @@ class RequestReactiveMethodsTest {
     val typeRegistry = KotlinTypeRegistry("io.test", null, GenerationMode.Client, setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry) { document ->
+      generate(testUri, typeRegistry) { document, shapeIndex ->
         KotlinJAXRSGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           KotlinJAXRSGenerator.Options(
             false,
@@ -446,9 +452,10 @@ class RequestReactiveMethodsTest {
     val typeRegistry = KotlinTypeRegistry("io.test", null, GenerationMode.Client, setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry) { document ->
+      generate(testUri, typeRegistry) { document, shapeIndex ->
         KotlinJAXRSGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           KotlinJAXRSGenerator.Options(
             false,
@@ -519,9 +526,10 @@ class RequestReactiveMethodsTest {
     val typeRegistry = KotlinTypeRegistry("io.test", null, GenerationMode.Client, setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry) { document ->
+      generate(testUri, typeRegistry) { document, shapeIndex ->
         KotlinJAXRSGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           KotlinJAXRSGenerator.Options(
             false,

--- a/generator/src/test/kotlin/io/outfoxx/sunday/generator/kotlin/jaxrs/RequestUriParamsTest.kt
+++ b/generator/src/test/kotlin/io/outfoxx/sunday/generator/kotlin/jaxrs/RequestUriParamsTest.kt
@@ -43,9 +43,10 @@ class RequestUriParamsTest {
     val typeRegistry = KotlinTypeRegistry("io.test", null, GenerationMode.Server, setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry) { document ->
+      generate(testUri, typeRegistry) { document, shapeIndex ->
         KotlinJAXRSGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           kotlinJAXRSTestOptions,
         )
@@ -97,9 +98,10 @@ class RequestUriParamsTest {
     val typeRegistry = KotlinTypeRegistry("io.test", null, GenerationMode.Server, setOf(ValidationConstraints))
 
     val builtTypes =
-      generate(testUri, typeRegistry) { document ->
+      generate(testUri, typeRegistry) { document, shapeIndex ->
         KotlinJAXRSGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           kotlinJAXRSTestOptions,
         )
@@ -152,9 +154,10 @@ class RequestUriParamsTest {
     val typeRegistry = KotlinTypeRegistry("io.test", null, GenerationMode.Server, setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry) { document ->
+      generate(testUri, typeRegistry) { document, shapeIndex ->
         KotlinJAXRSGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           kotlinJAXRSTestOptions,
         )
@@ -206,9 +209,10 @@ class RequestUriParamsTest {
     val typeRegistry = KotlinTypeRegistry("io.test", null, GenerationMode.Server, setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry) { document ->
+      generate(testUri, typeRegistry) { document, shapeIndex ->
         KotlinJAXRSGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           kotlinJAXRSTestOptions,
         )
@@ -262,9 +266,10 @@ class RequestUriParamsTest {
     val typeRegistry = KotlinTypeRegistry("io.test", null, GenerationMode.Server, setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry) { document ->
+      generate(testUri, typeRegistry) { document, shapeIndex ->
         KotlinJAXRSGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           kotlinJAXRSTestOptions,
         )

--- a/generator/src/test/kotlin/io/outfoxx/sunday/generator/kotlin/jaxrs/ResponseAsyncTest.kt
+++ b/generator/src/test/kotlin/io/outfoxx/sunday/generator/kotlin/jaxrs/ResponseAsyncTest.kt
@@ -42,9 +42,10 @@ class ResponseAsyncTest {
     val typeRegistry = KotlinTypeRegistry("io.test", null, GenerationMode.Server, setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry) { document ->
+      generate(testUri, typeRegistry) { document, shapeIndex ->
         KotlinJAXRSGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           kotlinJAXRSTestOptions,
         )

--- a/generator/src/test/kotlin/io/outfoxx/sunday/generator/kotlin/jaxrs/ResponseBodyContentTest.kt
+++ b/generator/src/test/kotlin/io/outfoxx/sunday/generator/kotlin/jaxrs/ResponseBodyContentTest.kt
@@ -42,9 +42,10 @@ class ResponseBodyContentTest {
     val typeRegistry = KotlinTypeRegistry("io.test", null, GenerationMode.Server, setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry) { document ->
+      generate(testUri, typeRegistry) { document, shapeIndex ->
         KotlinJAXRSGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           kotlinJAXRSTestOptions,
         )
@@ -86,9 +87,10 @@ class ResponseBodyContentTest {
     val typeRegistry = KotlinTypeRegistry("io.test", null, GenerationMode.Server, setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry) { document ->
+      generate(testUri, typeRegistry) { document, shapeIndex ->
         KotlinJAXRSGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           kotlinJAXRSTestOptions,
         )
@@ -131,9 +133,10 @@ class ResponseBodyContentTest {
     val typeRegistry = KotlinTypeRegistry("io.test", null, GenerationMode.Client, setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry) { document ->
+      generate(testUri, typeRegistry) { document, shapeIndex ->
         KotlinJAXRSGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           kotlinJAXRSTestOptions,
         )
@@ -175,9 +178,10 @@ class ResponseBodyContentTest {
     val typeRegistry = KotlinTypeRegistry("io.test", null, GenerationMode.Client, setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry) { document ->
+      generate(testUri, typeRegistry) { document, shapeIndex ->
         KotlinJAXRSGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           kotlinJAXRSTestOptions,
         )
@@ -220,9 +224,10 @@ class ResponseBodyContentTest {
     val typeRegistry = KotlinTypeRegistry("io.test", null, GenerationMode.Client, setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry) { document ->
+      generate(testUri, typeRegistry) { document, shapeIndex ->
         KotlinJAXRSGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           kotlinJAXRSTestOptions,
         )
@@ -268,9 +273,10 @@ class ResponseBodyContentTest {
     val typeRegistry = KotlinTypeRegistry("io.test", null, GenerationMode.Server, setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry) { document ->
+      generate(testUri, typeRegistry) { document, shapeIndex ->
         KotlinJAXRSGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           kotlinJAXRSTestOptions,
         )
@@ -317,9 +323,10 @@ class ResponseBodyContentTest {
     val typeRegistry = KotlinTypeRegistry("io.test", null, GenerationMode.Client, setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry) { document ->
+      generate(testUri, typeRegistry) { document, shapeIndex ->
         KotlinJAXRSGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           kotlinJAXRSTestOptions,
         )
@@ -361,9 +368,10 @@ class ResponseBodyContentTest {
     val typeRegistry = KotlinTypeRegistry("io.test", null, GenerationMode.Server, setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry) { document ->
+      generate(testUri, typeRegistry) { document, shapeIndex ->
         KotlinJAXRSGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           kotlinJAXRSTestOptions,
         )

--- a/generator/src/test/kotlin/io/outfoxx/sunday/generator/kotlin/jaxrs/ResponseProblemsTest.kt
+++ b/generator/src/test/kotlin/io/outfoxx/sunday/generator/kotlin/jaxrs/ResponseProblemsTest.kt
@@ -46,9 +46,10 @@ class ResponseProblemsTest {
     val typeRegistry = KotlinTypeRegistry("io.test", null, GenerationMode.Server, setOf(JacksonAnnotations))
 
     val builtTypes =
-      generate(testUri, typeRegistry) { document ->
+      generate(testUri, typeRegistry) { document, shapeIndex ->
         KotlinJAXRSGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           kotlinJAXRSTestOptions,
         )
@@ -90,9 +91,10 @@ class ResponseProblemsTest {
     val typeRegistry = KotlinTypeRegistry("io.test", null, GenerationMode.Client, setOf(JacksonAnnotations))
 
     val builtTypes =
-      generate(testUri, typeRegistry) { document ->
+      generate(testUri, typeRegistry) { document, shapeIndex ->
         KotlinJAXRSGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           kotlinJAXRSTestOptions,
         )
@@ -134,9 +136,10 @@ class ResponseProblemsTest {
     val typeRegistry = KotlinTypeRegistry("io.test", null, GenerationMode.Server, setOf(JacksonAnnotations))
 
     val builtTypes =
-      generate(testUri, typeRegistry) { document ->
+      generate(testUri, typeRegistry) { document, shapeIndex ->
         KotlinJAXRSGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           kotlinJAXRSTestOptions,
         )
@@ -191,9 +194,10 @@ class ResponseProblemsTest {
     val typeRegistry = KotlinTypeRegistry("io.test", null, GenerationMode.Client, setOf(JacksonAnnotations))
 
     val builtTypes =
-      generate(testUri, typeRegistry) { document ->
+      generate(testUri, typeRegistry) { document, shapeIndex ->
         KotlinJAXRSGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           kotlinJAXRSTestOptions,
         )
@@ -248,9 +252,10 @@ class ResponseProblemsTest {
     val typeRegistry = KotlinTypeRegistry("io.test", null, GenerationMode.Server, setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry) { document ->
+      generate(testUri, typeRegistry) { document, shapeIndex ->
         KotlinJAXRSGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           kotlinJAXRSTestOptions,
         )
@@ -305,9 +310,10 @@ class ResponseProblemsTest {
     val typeRegistry = KotlinTypeRegistry("io.test", null, GenerationMode.Client, setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry) { document ->
+      generate(testUri, typeRegistry) { document, shapeIndex ->
         KotlinJAXRSGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           kotlinJAXRSTestOptions,
         )
@@ -362,9 +368,10 @@ class ResponseProblemsTest {
     val typeRegistry = KotlinTypeRegistry("io.test", null, GenerationMode.Server, setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry) { document ->
+      generate(testUri, typeRegistry) { document, shapeIndex ->
         KotlinJAXRSGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           kotlinJAXRSTestOptions,
         )
@@ -419,9 +426,10 @@ class ResponseProblemsTest {
     val typeRegistry = KotlinTypeRegistry("io.test", null, GenerationMode.Server, setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry) { document ->
+      generate(testUri, typeRegistry) { document, shapeIndex ->
         KotlinJAXRSGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           kotlinJAXRSTestOptions,
         )
@@ -476,9 +484,10 @@ class ResponseProblemsTest {
     val typeRegistry = KotlinTypeRegistry("io.test", null, GenerationMode.Server, setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry) { document ->
+      generate(testUri, typeRegistry) { document, shapeIndex ->
         KotlinJAXRSGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           kotlinJAXRSTestOptions,
         )
@@ -533,9 +542,10 @@ class ResponseProblemsTest {
     val typeRegistry = KotlinTypeRegistry("io.test", null, GenerationMode.Server, setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry) { document ->
+      generate(testUri, typeRegistry) { document, shapeIndex ->
         KotlinJAXRSGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           kotlinJAXRSTestOptions,
         )

--- a/generator/src/test/kotlin/io/outfoxx/sunday/generator/kotlin/jaxrs/ResponseSseTest.kt
+++ b/generator/src/test/kotlin/io/outfoxx/sunday/generator/kotlin/jaxrs/ResponseSseTest.kt
@@ -42,9 +42,10 @@ class ResponseSseTest {
     val typeRegistry = KotlinTypeRegistry("io.test", null, GenerationMode.Server, setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry) { document ->
+      generate(testUri, typeRegistry) { document, shapeIndex ->
         KotlinJAXRSGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           kotlinJAXRSTestOptions,
         )
@@ -89,9 +90,10 @@ class ResponseSseTest {
     val typeRegistry = KotlinTypeRegistry("io.test", null, GenerationMode.Client, setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry) { document ->
+      generate(testUri, typeRegistry) { document, shapeIndex ->
         KotlinJAXRSGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           kotlinJAXRSTestOptions,
         )

--- a/generator/src/test/kotlin/io/outfoxx/sunday/generator/kotlin/jaxrs/ServiceTest.kt
+++ b/generator/src/test/kotlin/io/outfoxx/sunday/generator/kotlin/jaxrs/ServiceTest.kt
@@ -54,9 +54,10 @@ class ServiceTest {
     )
 
     val builtTypes =
-      generate(testUri, typeRegistry) { document ->
+      generate(testUri, typeRegistry) { document, shapeIndex ->
         KotlinJAXRSGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           options,
         )

--- a/generator/src/test/kotlin/io/outfoxx/sunday/generator/kotlin/sunday/BaseUriTest.kt
+++ b/generator/src/test/kotlin/io/outfoxx/sunday/generator/kotlin/sunday/BaseUriTest.kt
@@ -44,9 +44,10 @@ class BaseUriTest {
     val typeRegistry = KotlinTypeRegistry("io.test", null, Client, setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry) { document ->
+      generate(testUri, typeRegistry) { document, shapeIndex ->
         KotlinSundayGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           kotlinSundayTestOptions,
         )

--- a/generator/src/test/kotlin/io/outfoxx/sunday/generator/kotlin/sunday/BuilderMethodsTest.kt
+++ b/generator/src/test/kotlin/io/outfoxx/sunday/generator/kotlin/sunday/BuilderMethodsTest.kt
@@ -42,9 +42,10 @@ class BuilderMethodsTest {
     val typeRegistry = KotlinTypeRegistry("io.test", null, GenerationMode.Client, setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry) { document ->
+      generate(testUri, typeRegistry) { document, shapeIndex ->
         KotlinSundayGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           kotlinSundayTestOptions,
         )
@@ -90,9 +91,10 @@ class BuilderMethodsTest {
     val typeRegistry = KotlinTypeRegistry("io.test", null, GenerationMode.Client, setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry) { document ->
+      generate(testUri, typeRegistry) { document, shapeIndex ->
         KotlinSundayGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           kotlinSundayTestOptions,
         )

--- a/generator/src/test/kotlin/io/outfoxx/sunday/generator/kotlin/sunday/RequestBodyParamTest.kt
+++ b/generator/src/test/kotlin/io/outfoxx/sunday/generator/kotlin/sunday/RequestBodyParamTest.kt
@@ -42,9 +42,10 @@ class RequestBodyParamTest {
     val typeRegistry = KotlinTypeRegistry("io.test", null, GenerationMode.Client, setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry) { document ->
+      generate(testUri, typeRegistry) { document, shapeIndex ->
         KotlinSundayGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           kotlinSundayTestOptions,
         )
@@ -92,9 +93,10 @@ class RequestBodyParamTest {
     val typeRegistry = KotlinTypeRegistry("io.test", null, GenerationMode.Client, setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry) { document ->
+      generate(testUri, typeRegistry) { document, shapeIndex ->
         KotlinSundayGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           kotlinSundayTestOptions,
         )
@@ -142,9 +144,10 @@ class RequestBodyParamTest {
     val typeRegistry = KotlinTypeRegistry("io.test", null, GenerationMode.Client, setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry) { document ->
+      generate(testUri, typeRegistry) { document, shapeIndex ->
         KotlinSundayGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           kotlinSundayTestOptions,
         )

--- a/generator/src/test/kotlin/io/outfoxx/sunday/generator/kotlin/sunday/RequestHeaderParamsTest.kt
+++ b/generator/src/test/kotlin/io/outfoxx/sunday/generator/kotlin/sunday/RequestHeaderParamsTest.kt
@@ -42,9 +42,10 @@ class RequestHeaderParamsTest {
     val typeRegistry = KotlinTypeRegistry("io.test", null, GenerationMode.Client, setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry) { document ->
+      generate(testUri, typeRegistry) { document, shapeIndex ->
         KotlinSundayGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           kotlinSundayTestOptions,
         )
@@ -101,9 +102,10 @@ class RequestHeaderParamsTest {
     val typeRegistry = KotlinTypeRegistry("io.test", null, GenerationMode.Client, setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry) { document ->
+      generate(testUri, typeRegistry) { document, shapeIndex ->
         KotlinSundayGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           kotlinSundayTestOptions,
         )
@@ -164,9 +166,10 @@ class RequestHeaderParamsTest {
     val typeRegistry = KotlinTypeRegistry("io.test", null, GenerationMode.Client, setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry) { document ->
+      generate(testUri, typeRegistry) { document, shapeIndex ->
         KotlinSundayGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           kotlinSundayTestOptions,
         )

--- a/generator/src/test/kotlin/io/outfoxx/sunday/generator/kotlin/sunday/RequestMethodsTest.kt
+++ b/generator/src/test/kotlin/io/outfoxx/sunday/generator/kotlin/sunday/RequestMethodsTest.kt
@@ -42,9 +42,10 @@ class RequestMethodsTest {
     val typeRegistry = KotlinTypeRegistry("io.test", null, GenerationMode.Client, setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry) { document ->
+      generate(testUri, typeRegistry) { document, shapeIndex ->
         KotlinSundayGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           kotlinSundayTestOptions,
         )
@@ -137,9 +138,10 @@ class RequestMethodsTest {
     val typeRegistry = KotlinTypeRegistry("io.test", null, GenerationMode.Client, setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry) { document ->
+      generate(testUri, typeRegistry) { document, shapeIndex ->
         KotlinSundayGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           kotlinSundayTestOptions,
         )

--- a/generator/src/test/kotlin/io/outfoxx/sunday/generator/kotlin/sunday/RequestMixedParamsTest.kt
+++ b/generator/src/test/kotlin/io/outfoxx/sunday/generator/kotlin/sunday/RequestMixedParamsTest.kt
@@ -42,9 +42,10 @@ class RequestMixedParamsTest {
     val typeRegistry = KotlinTypeRegistry("io.test", null, GenerationMode.Client, setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry) { document ->
+      generate(testUri, typeRegistry) { document, shapeIndex ->
         KotlinSundayGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           kotlinSundayTestOptions,
         )
@@ -120,9 +121,10 @@ class RequestMixedParamsTest {
     val typeRegistry = KotlinTypeRegistry("io.test", null, GenerationMode.Client, setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry) { document ->
+      generate(testUri, typeRegistry) { document, shapeIndex ->
         KotlinSundayGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           kotlinSundayTestOptions,
         )

--- a/generator/src/test/kotlin/io/outfoxx/sunday/generator/kotlin/sunday/RequestQueryParamsTest.kt
+++ b/generator/src/test/kotlin/io/outfoxx/sunday/generator/kotlin/sunday/RequestQueryParamsTest.kt
@@ -42,9 +42,10 @@ class RequestQueryParamsTest {
     val typeRegistry = KotlinTypeRegistry("io.test", null, GenerationMode.Client, setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry) { document ->
+      generate(testUri, typeRegistry) { document, shapeIndex ->
         KotlinSundayGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           kotlinSundayTestOptions,
         )
@@ -101,9 +102,10 @@ class RequestQueryParamsTest {
     val typeRegistry = KotlinTypeRegistry("io.test", null, GenerationMode.Client, setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry) { document ->
+      generate(testUri, typeRegistry) { document, shapeIndex ->
         KotlinSundayGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           kotlinSundayTestOptions,
         )
@@ -164,9 +166,10 @@ class RequestQueryParamsTest {
     val typeRegistry = KotlinTypeRegistry("io.test", null, GenerationMode.Client, setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry) { document ->
+      generate(testUri, typeRegistry) { document, shapeIndex ->
         KotlinSundayGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           kotlinSundayTestOptions,
         )

--- a/generator/src/test/kotlin/io/outfoxx/sunday/generator/kotlin/sunday/RequestUriParamsTest.kt
+++ b/generator/src/test/kotlin/io/outfoxx/sunday/generator/kotlin/sunday/RequestUriParamsTest.kt
@@ -42,9 +42,10 @@ class RequestUriParamsTest {
     val typeRegistry = KotlinTypeRegistry("io.test", null, GenerationMode.Client, setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry) { document ->
+      generate(testUri, typeRegistry) { document, shapeIndex ->
         KotlinSundayGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           kotlinSundayTestOptions,
         )
@@ -103,9 +104,10 @@ class RequestUriParamsTest {
     val typeRegistry = KotlinTypeRegistry("io.test", null, GenerationMode.Client, setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry) { document ->
+      generate(testUri, typeRegistry) { document, shapeIndex ->
         KotlinSundayGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           kotlinSundayTestOptions,
         )
@@ -165,9 +167,10 @@ class RequestUriParamsTest {
     val typeRegistry = KotlinTypeRegistry("io.test", null, GenerationMode.Client, setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry) { document ->
+      generate(testUri, typeRegistry) { document, shapeIndex ->
         KotlinSundayGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           kotlinSundayTestOptions,
         )
@@ -230,9 +233,10 @@ class RequestUriParamsTest {
     val typeRegistry = KotlinTypeRegistry("io.test", null, GenerationMode.Client, setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry) { document ->
+      generate(testUri, typeRegistry) { document, shapeIndex ->
         KotlinSundayGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           kotlinSundayTestOptions,
         )

--- a/generator/src/test/kotlin/io/outfoxx/sunday/generator/kotlin/sunday/ResponseBodyContentTest.kt
+++ b/generator/src/test/kotlin/io/outfoxx/sunday/generator/kotlin/sunday/ResponseBodyContentTest.kt
@@ -42,9 +42,10 @@ class ResponseBodyContentTest {
     val typeRegistry = KotlinTypeRegistry("io.test", null, GenerationMode.Client, setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry) { document ->
+      generate(testUri, typeRegistry) { document, shapeIndex ->
         KotlinSundayGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           kotlinSundayTestOptions,
         )
@@ -90,9 +91,10 @@ class ResponseBodyContentTest {
     val typeRegistry = KotlinTypeRegistry("io.test", null, GenerationMode.Client, setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry) { document ->
+      generate(testUri, typeRegistry) { document, shapeIndex ->
         KotlinSundayGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           kotlinSundayTestOptions,
         )
@@ -138,9 +140,10 @@ class ResponseBodyContentTest {
     val typeRegistry = KotlinTypeRegistry("io.test", null, GenerationMode.Client, setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry) { document ->
+      generate(testUri, typeRegistry) { document, shapeIndex ->
         KotlinSundayGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           kotlinSundayTestOptions,
         )
@@ -190,9 +193,10 @@ class ResponseBodyContentTest {
     val typeRegistry = KotlinTypeRegistry("io.test", null, GenerationMode.Client, setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry) { document ->
+      generate(testUri, typeRegistry) { document, shapeIndex ->
         KotlinSundayGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           kotlinSundayTestOptions,
         )

--- a/generator/src/test/kotlin/io/outfoxx/sunday/generator/kotlin/sunday/ResponseEventsTest.kt
+++ b/generator/src/test/kotlin/io/outfoxx/sunday/generator/kotlin/sunday/ResponseEventsTest.kt
@@ -42,9 +42,10 @@ class ResponseEventsTest {
     val typeRegistry = KotlinTypeRegistry("io.test", null, GenerationMode.Client, setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry) { document ->
+      generate(testUri, typeRegistry) { document, shapeIndex ->
         KotlinSundayGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           kotlinSundayTestOptions,
         )
@@ -90,9 +91,10 @@ class ResponseEventsTest {
     val typeRegistry = KotlinTypeRegistry("io.test", null, GenerationMode.Client, setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry) { document ->
+      generate(testUri, typeRegistry) { document, shapeIndex ->
         KotlinSundayGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           kotlinSundayTestOptions,
         )
@@ -161,9 +163,10 @@ class ResponseEventsTest {
     val typeRegistry = KotlinTypeRegistry("io.test", null, GenerationMode.Client, setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry) { document ->
+      generate(testUri, typeRegistry) { document, shapeIndex ->
         KotlinSundayGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           kotlinSundayTestOptions,
         )

--- a/generator/src/test/kotlin/io/outfoxx/sunday/generator/kotlin/sunday/ResponseProblemsTest.kt
+++ b/generator/src/test/kotlin/io/outfoxx/sunday/generator/kotlin/sunday/ResponseProblemsTest.kt
@@ -46,9 +46,10 @@ class ResponseProblemsTest {
     val typeRegistry = KotlinTypeRegistry("io.test", null, GenerationMode.Client, setOf(JacksonAnnotations))
 
     val builtTypes =
-      generate(testUri, typeRegistry) { document ->
+      generate(testUri, typeRegistry) { document, shapeIndex ->
         KotlinSundayGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           kotlinSundayTestOptions,
         )
@@ -100,9 +101,10 @@ class ResponseProblemsTest {
     val typeRegistry = KotlinTypeRegistry("io.test", null, GenerationMode.Client, setOf(JacksonAnnotations))
 
     val builtTypes =
-      generate(testUri, typeRegistry) { document ->
+      generate(testUri, typeRegistry) { document, shapeIndex ->
         KotlinSundayGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           kotlinSundayTestOptions,
         )
@@ -148,9 +150,10 @@ class ResponseProblemsTest {
     val typeRegistry = KotlinTypeRegistry("io.test", null, GenerationMode.Client, setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry) { document ->
+      generate(testUri, typeRegistry) { document, shapeIndex ->
         KotlinSundayGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           kotlinSundayTestOptions,
         )
@@ -205,9 +208,10 @@ class ResponseProblemsTest {
     val typeRegistry = KotlinTypeRegistry("io.test", null, GenerationMode.Client, setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry) { document ->
+      generate(testUri, typeRegistry) { document, shapeIndex ->
         KotlinSundayGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           kotlinSundayTestOptions,
         )
@@ -262,9 +266,10 @@ class ResponseProblemsTest {
     val typeRegistry = KotlinTypeRegistry("io.test", null, GenerationMode.Client, setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry) { document ->
+      generate(testUri, typeRegistry) { document, shapeIndex ->
         KotlinSundayGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           kotlinSundayTestOptions,
         )
@@ -319,9 +324,10 @@ class ResponseProblemsTest {
     val typeRegistry = KotlinTypeRegistry("io.test", null, GenerationMode.Client, setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry) { document ->
+      generate(testUri, typeRegistry) { document, shapeIndex ->
         KotlinSundayGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           kotlinSundayTestOptions,
         )
@@ -376,9 +382,10 @@ class ResponseProblemsTest {
     val typeRegistry = KotlinTypeRegistry("io.test", null, GenerationMode.Client, setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry) { document ->
+      generate(testUri, typeRegistry) { document, shapeIndex ->
         KotlinSundayGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           kotlinSundayTestOptions,
         )

--- a/generator/src/test/kotlin/io/outfoxx/sunday/generator/swift/sunday/BaseUriTest.kt
+++ b/generator/src/test/kotlin/io/outfoxx/sunday/generator/swift/sunday/BaseUriTest.kt
@@ -46,9 +46,10 @@ class BaseUriTest {
     val typeRegistry = SwiftTypeRegistry(setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry, compiler) { document ->
+      generate(testUri, typeRegistry, compiler) { document, shapeIndex ->
         SwiftSundayGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           swiftSundayTestOptions,
         )

--- a/generator/src/test/kotlin/io/outfoxx/sunday/generator/swift/sunday/BuilderMethodsTest.kt
+++ b/generator/src/test/kotlin/io/outfoxx/sunday/generator/swift/sunday/BuilderMethodsTest.kt
@@ -44,9 +44,10 @@ class BuilderMethodsTest {
     val typeRegistry = SwiftTypeRegistry(setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry, compiler) { document ->
+      generate(testUri, typeRegistry, compiler) { document, shapeIndex ->
         SwiftSundayGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           swiftSundayTestOptions,
         )
@@ -107,9 +108,10 @@ class BuilderMethodsTest {
     val typeRegistry = SwiftTypeRegistry(setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry, compiler) { document ->
+      generate(testUri, typeRegistry, compiler) { document, shapeIndex ->
         SwiftSundayGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           swiftSundayTestOptions,
         )

--- a/generator/src/test/kotlin/io/outfoxx/sunday/generator/swift/sunday/RequestBodyParamTest.kt
+++ b/generator/src/test/kotlin/io/outfoxx/sunday/generator/swift/sunday/RequestBodyParamTest.kt
@@ -44,9 +44,10 @@ class RequestBodyParamTest {
     val typeRegistry = SwiftTypeRegistry(setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry, compiler) { document ->
+      generate(testUri, typeRegistry, compiler) { document, shapeIndex ->
         SwiftSundayGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           swiftSundayTestOptions,
         )
@@ -106,9 +107,10 @@ class RequestBodyParamTest {
     val typeRegistry = SwiftTypeRegistry(setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry, compiler) { document ->
+      generate(testUri, typeRegistry, compiler) { document, shapeIndex ->
         SwiftSundayGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           swiftSundayTestOptions,
         )
@@ -168,9 +170,10 @@ class RequestBodyParamTest {
     val typeRegistry = SwiftTypeRegistry(setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry, compiler) { document ->
+      generate(testUri, typeRegistry, compiler) { document, shapeIndex ->
         SwiftSundayGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           swiftSundayTestOptions,
         )

--- a/generator/src/test/kotlin/io/outfoxx/sunday/generator/swift/sunday/RequestHeaderParamsTest.kt
+++ b/generator/src/test/kotlin/io/outfoxx/sunday/generator/swift/sunday/RequestHeaderParamsTest.kt
@@ -44,9 +44,10 @@ class RequestHeaderParamsTest {
     val typeRegistry = SwiftTypeRegistry(setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry, compiler) { document ->
+      generate(testUri, typeRegistry, compiler) { document, shapeIndex ->
         SwiftSundayGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           swiftSundayTestOptions,
         )
@@ -114,9 +115,10 @@ class RequestHeaderParamsTest {
     val typeRegistry = SwiftTypeRegistry(setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry, compiler) { document ->
+      generate(testUri, typeRegistry, compiler) { document, shapeIndex ->
         SwiftSundayGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           swiftSundayTestOptions,
         )
@@ -188,9 +190,10 @@ class RequestHeaderParamsTest {
     val typeRegistry = SwiftTypeRegistry(setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry, compiler) { document ->
+      generate(testUri, typeRegistry, compiler) { document, shapeIndex ->
         SwiftSundayGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           swiftSundayTestOptions,
         )

--- a/generator/src/test/kotlin/io/outfoxx/sunday/generator/swift/sunday/RequestMethodsTest.kt
+++ b/generator/src/test/kotlin/io/outfoxx/sunday/generator/swift/sunday/RequestMethodsTest.kt
@@ -44,9 +44,10 @@ class RequestMethodsTest {
     val typeRegistry = SwiftTypeRegistry(setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry, compiler) { document ->
+      generate(testUri, typeRegistry, compiler) { document, shapeIndex ->
         SwiftSundayGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           swiftSundayTestOptions,
         )
@@ -197,9 +198,10 @@ class RequestMethodsTest {
     val typeRegistry = SwiftTypeRegistry(setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry, compiler) { document ->
+      generate(testUri, typeRegistry, compiler) { document, shapeIndex ->
         SwiftSundayGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           swiftSundayTestOptions,
         )

--- a/generator/src/test/kotlin/io/outfoxx/sunday/generator/swift/sunday/RequestMixedParamsTest.kt
+++ b/generator/src/test/kotlin/io/outfoxx/sunday/generator/swift/sunday/RequestMixedParamsTest.kt
@@ -44,9 +44,10 @@ class RequestMixedParamsTest {
     val typeRegistry = SwiftTypeRegistry(setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry, compiler) { document ->
+      generate(testUri, typeRegistry, compiler) { document, shapeIndex ->
         SwiftSundayGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           swiftSundayTestOptions,
         )
@@ -138,9 +139,10 @@ class RequestMixedParamsTest {
     val typeRegistry = SwiftTypeRegistry(setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry, compiler) { document ->
+      generate(testUri, typeRegistry, compiler) { document, shapeIndex ->
         SwiftSundayGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           swiftSundayTestOptions,
         )

--- a/generator/src/test/kotlin/io/outfoxx/sunday/generator/swift/sunday/RequestQueryParamsTest.kt
+++ b/generator/src/test/kotlin/io/outfoxx/sunday/generator/swift/sunday/RequestQueryParamsTest.kt
@@ -44,9 +44,10 @@ class RequestQueryParamsTest {
     val typeRegistry = SwiftTypeRegistry(setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry, compiler) { document ->
+      generate(testUri, typeRegistry, compiler) { document, shapeIndex ->
         SwiftSundayGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           swiftSundayTestOptions,
         )
@@ -114,9 +115,10 @@ class RequestQueryParamsTest {
     val typeRegistry = SwiftTypeRegistry(setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry, compiler) { document ->
+      generate(testUri, typeRegistry, compiler) { document, shapeIndex ->
         SwiftSundayGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           swiftSundayTestOptions,
         )
@@ -188,9 +190,10 @@ class RequestQueryParamsTest {
     val typeRegistry = SwiftTypeRegistry(setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry, compiler) { document ->
+      generate(testUri, typeRegistry, compiler) { document, shapeIndex ->
         SwiftSundayGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           swiftSundayTestOptions,
         )

--- a/generator/src/test/kotlin/io/outfoxx/sunday/generator/swift/sunday/RequestUriParamsTest.kt
+++ b/generator/src/test/kotlin/io/outfoxx/sunday/generator/swift/sunday/RequestUriParamsTest.kt
@@ -44,9 +44,10 @@ class RequestUriParamsTest {
     val typeRegistry = SwiftTypeRegistry(setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry, compiler) { document ->
+      generate(testUri, typeRegistry, compiler) { document, shapeIndex ->
         SwiftSundayGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           swiftSundayTestOptions,
         )
@@ -116,9 +117,10 @@ class RequestUriParamsTest {
     val typeRegistry = SwiftTypeRegistry(setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry, compiler) { document ->
+      generate(testUri, typeRegistry, compiler) { document, shapeIndex ->
         SwiftSundayGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           swiftSundayTestOptions,
         )
@@ -189,9 +191,10 @@ class RequestUriParamsTest {
     val typeRegistry = SwiftTypeRegistry(setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry, compiler) { document ->
+      generate(testUri, typeRegistry, compiler) { document, shapeIndex ->
         SwiftSundayGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           swiftSundayTestOptions,
         )
@@ -265,9 +268,10 @@ class RequestUriParamsTest {
     val typeRegistry = SwiftTypeRegistry(setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry, compiler) { document ->
+      generate(testUri, typeRegistry, compiler) { document, shapeIndex ->
         SwiftSundayGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           swiftSundayTestOptions,
         )

--- a/generator/src/test/kotlin/io/outfoxx/sunday/generator/swift/sunday/ResponseBodyContentTest.kt
+++ b/generator/src/test/kotlin/io/outfoxx/sunday/generator/swift/sunday/ResponseBodyContentTest.kt
@@ -44,9 +44,10 @@ class ResponseBodyContentTest {
     val typeRegistry = SwiftTypeRegistry(setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry, compiler) { document ->
+      generate(testUri, typeRegistry, compiler) { document, shapeIndex ->
         SwiftSundayGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           swiftSundayTestOptions,
         )
@@ -106,9 +107,10 @@ class ResponseBodyContentTest {
     val typeRegistry = SwiftTypeRegistry(setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry, compiler) { document ->
+      generate(testUri, typeRegistry, compiler) { document, shapeIndex ->
         SwiftSundayGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           swiftSundayTestOptions,
         )
@@ -169,9 +171,10 @@ class ResponseBodyContentTest {
     val typeRegistry = SwiftTypeRegistry(setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry, compiler) { document ->
+      generate(testUri, typeRegistry, compiler) { document, shapeIndex ->
         SwiftSundayGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           swiftSundayTestOptions,
         )
@@ -266,9 +269,10 @@ class ResponseBodyContentTest {
     val typeRegistry = SwiftTypeRegistry(setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry, compiler) { document ->
+      generate(testUri, typeRegistry, compiler) { document, shapeIndex ->
         SwiftSundayGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           swiftSundayTestOptions,
         )

--- a/generator/src/test/kotlin/io/outfoxx/sunday/generator/swift/sunday/ResponseEventsTest.kt
+++ b/generator/src/test/kotlin/io/outfoxx/sunday/generator/swift/sunday/ResponseEventsTest.kt
@@ -44,9 +44,10 @@ class ResponseEventsTest {
     val typeRegistry = SwiftTypeRegistry(setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry, compiler) { document ->
+      generate(testUri, typeRegistry, compiler) { document, shapeIndex ->
         SwiftSundayGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           swiftSundayTestOptions,
         )
@@ -105,9 +106,10 @@ class ResponseEventsTest {
     val typeRegistry = SwiftTypeRegistry(setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry, compiler) { document ->
+      generate(testUri, typeRegistry, compiler) { document, shapeIndex ->
         SwiftSundayGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           swiftSundayTestOptions,
         )
@@ -191,9 +193,10 @@ class ResponseEventsTest {
     val typeRegistry = SwiftTypeRegistry(setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry, compiler) { document ->
+      generate(testUri, typeRegistry, compiler) { document, shapeIndex ->
         SwiftSundayGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           swiftSundayTestOptions,
         )

--- a/generator/src/test/kotlin/io/outfoxx/sunday/generator/swift/sunday/ResponseProblemsTest.kt
+++ b/generator/src/test/kotlin/io/outfoxx/sunday/generator/swift/sunday/ResponseProblemsTest.kt
@@ -47,9 +47,10 @@ class ResponseProblemsTest {
     val typeRegistry = SwiftTypeRegistry(setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry, compiler) { document ->
+      generate(testUri, typeRegistry, compiler) { document, shapeIndex ->
         SwiftSundayGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           swiftSundayTestOptions,
         )
@@ -111,9 +112,10 @@ class ResponseProblemsTest {
     val typeRegistry = SwiftTypeRegistry(setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry, compiler) { document ->
+      generate(testUri, typeRegistry, compiler) { document, shapeIndex ->
         SwiftSundayGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           swiftSundayTestOptions,
         )
@@ -173,9 +175,10 @@ class ResponseProblemsTest {
     val typeRegistry = SwiftTypeRegistry(setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry, compiler) { document ->
+      generate(testUri, typeRegistry, compiler) { document, shapeIndex ->
         SwiftSundayGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           swiftSundayTestOptions,
         )
@@ -250,9 +253,10 @@ class ResponseProblemsTest {
     val typeRegistry = SwiftTypeRegistry(setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry, compiler) { document ->
+      generate(testUri, typeRegistry, compiler) { document, shapeIndex ->
         SwiftSundayGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           swiftSundayTestOptions,
         )
@@ -327,9 +331,10 @@ class ResponseProblemsTest {
     val typeRegistry = SwiftTypeRegistry(setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry, compiler) { document ->
+      generate(testUri, typeRegistry, compiler) { document, shapeIndex ->
         SwiftSundayGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           swiftSundayTestOptions,
         )
@@ -404,9 +409,10 @@ class ResponseProblemsTest {
     val typeRegistry = SwiftTypeRegistry(setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry, compiler) { document ->
+      generate(testUri, typeRegistry, compiler) { document, shapeIndex ->
         SwiftSundayGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           swiftSundayTestOptions,
         )
@@ -481,9 +487,10 @@ class ResponseProblemsTest {
     val typeRegistry = SwiftTypeRegistry(setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry, compiler) { document ->
+      generate(testUri, typeRegistry, compiler) { document, shapeIndex ->
         SwiftSundayGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           swiftSundayTestOptions,
         )

--- a/generator/src/test/kotlin/io/outfoxx/sunday/generator/typescript/RamlObjectTypesTest.kt
+++ b/generator/src/test/kotlin/io/outfoxx/sunday/generator/typescript/RamlObjectTypesTest.kt
@@ -156,9 +156,10 @@ class RamlObjectTypesTest {
     val typeRegistry = TypeScriptTypeRegistry(setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry, compiler) {
+      generate(testUri, typeRegistry, compiler) { document, shapeIndex ->
         TypeScriptSundayGenerator(
-          it,
+          document,
+          shapeIndex,
           typeRegistry,
           typeScriptSundayTestOptions
         )

--- a/generator/src/test/kotlin/io/outfoxx/sunday/generator/typescript/RamlTypeAnnotationsTest.kt
+++ b/generator/src/test/kotlin/io/outfoxx/sunday/generator/typescript/RamlTypeAnnotationsTest.kt
@@ -80,8 +80,13 @@ class RamlTypeAnnotationsTest {
 
     val typeRegistry = TypeScriptTypeRegistry(setOf())
 
-    val generatedTypes = generate(testUri, typeRegistry, compiler) {
-      TypeScriptSundayGenerator(it, typeRegistry, typeScriptSundayTestOptions)
+    val generatedTypes = generate(testUri, typeRegistry, compiler) { document, shapeIndex ->
+      TypeScriptSundayGenerator(
+        document,
+        shapeIndex,
+        typeRegistry,
+        typeScriptSundayTestOptions
+      )
     }
 
     assertThat(generatedTypes.keys, hasItem(TypeName.namedImport("API", "!explicit/client/api")))

--- a/generator/src/test/kotlin/io/outfoxx/sunday/generator/typescript/sunday/BaseUriTest.kt
+++ b/generator/src/test/kotlin/io/outfoxx/sunday/generator/typescript/sunday/BaseUriTest.kt
@@ -44,9 +44,10 @@ class BaseUriTest {
     val typeRegistry = TypeScriptTypeRegistry(setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry, compiler) { document ->
+      generate(testUri, typeRegistry, compiler) { document, shapeIndex ->
         TypeScriptSundayGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           typeScriptSundayTestOptions,
         )

--- a/generator/src/test/kotlin/io/outfoxx/sunday/generator/typescript/sunday/BuilderMethodsTest.kt
+++ b/generator/src/test/kotlin/io/outfoxx/sunday/generator/typescript/sunday/BuilderMethodsTest.kt
@@ -44,9 +44,10 @@ class BuilderMethodsTest {
     val typeRegistry = TypeScriptTypeRegistry(setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry, compiler) { document ->
+      generate(testUri, typeRegistry, compiler) { document, shapeIndex ->
         TypeScriptSundayGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           typeScriptSundayTestOptions,
         )
@@ -103,9 +104,10 @@ class BuilderMethodsTest {
     val typeRegistry = TypeScriptTypeRegistry(setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry, compiler) { document ->
+      generate(testUri, typeRegistry, compiler) { document, shapeIndex ->
         TypeScriptSundayGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           typeScriptSundayTestOptions,
         )

--- a/generator/src/test/kotlin/io/outfoxx/sunday/generator/typescript/sunday/RequestBodyParamTest.kt
+++ b/generator/src/test/kotlin/io/outfoxx/sunday/generator/typescript/sunday/RequestBodyParamTest.kt
@@ -44,9 +44,10 @@ class RequestBodyParamTest {
     val typeRegistry = TypeScriptTypeRegistry(setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry, compiler) { document ->
+      generate(testUri, typeRegistry, compiler) { document, shapeIndex ->
         TypeScriptSundayGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           typeScriptSundayTestOptions,
         )
@@ -111,9 +112,10 @@ class RequestBodyParamTest {
     val typeRegistry = TypeScriptTypeRegistry(setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry, compiler) { document ->
+      generate(testUri, typeRegistry, compiler) { document, shapeIndex ->
         TypeScriptSundayGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           typeScriptSundayTestOptions,
         )
@@ -178,9 +180,10 @@ class RequestBodyParamTest {
     val typeRegistry = TypeScriptTypeRegistry(setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry, compiler) { document ->
+      generate(testUri, typeRegistry, compiler) { document, shapeIndex ->
         TypeScriptSundayGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           typeScriptSundayTestOptions,
         )

--- a/generator/src/test/kotlin/io/outfoxx/sunday/generator/typescript/sunday/RequestHeaderParamsTest.kt
+++ b/generator/src/test/kotlin/io/outfoxx/sunday/generator/typescript/sunday/RequestHeaderParamsTest.kt
@@ -44,9 +44,10 @@ class RequestHeaderParamsTest {
     val typeRegistry = TypeScriptTypeRegistry(setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry, compiler) { document ->
+      generate(testUri, typeRegistry, compiler) { document, shapeIndex ->
         TypeScriptSundayGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           typeScriptSundayTestOptions,
         )
@@ -112,9 +113,10 @@ class RequestHeaderParamsTest {
     val typeRegistry = TypeScriptTypeRegistry(setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry, compiler) { document ->
+      generate(testUri, typeRegistry, compiler) { document, shapeIndex ->
         TypeScriptSundayGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           typeScriptSundayTestOptions,
         )
@@ -188,9 +190,10 @@ class RequestHeaderParamsTest {
     val typeRegistry = TypeScriptTypeRegistry(setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry, compiler) { document ->
+      generate(testUri, typeRegistry, compiler) { document, shapeIndex ->
         TypeScriptSundayGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           typeScriptSundayTestOptions,
         )

--- a/generator/src/test/kotlin/io/outfoxx/sunday/generator/typescript/sunday/RequestMethodsTest.kt
+++ b/generator/src/test/kotlin/io/outfoxx/sunday/generator/typescript/sunday/RequestMethodsTest.kt
@@ -44,9 +44,10 @@ class RequestMethodsTest {
     val typeRegistry = TypeScriptTypeRegistry(setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry, compiler) { document ->
+      generate(testUri, typeRegistry, compiler) { document, shapeIndex ->
         TypeScriptSundayGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           typeScriptSundayTestOptions,
         )
@@ -199,9 +200,10 @@ class RequestMethodsTest {
     val typeRegistry = TypeScriptTypeRegistry(setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry, compiler) { document ->
+      generate(testUri, typeRegistry, compiler) { document, shapeIndex ->
         TypeScriptSundayGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           typeScriptSundayTestOptions,
         )

--- a/generator/src/test/kotlin/io/outfoxx/sunday/generator/typescript/sunday/RequestMixedParamsTest.kt
+++ b/generator/src/test/kotlin/io/outfoxx/sunday/generator/typescript/sunday/RequestMixedParamsTest.kt
@@ -44,9 +44,10 @@ class RequestMixedParamsTest {
     val typeRegistry = TypeScriptTypeRegistry(setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry, compiler) { document ->
+      generate(testUri, typeRegistry, compiler) { document, shapeIndex ->
         TypeScriptSundayGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           typeScriptSundayTestOptions,
         )
@@ -135,9 +136,10 @@ class RequestMixedParamsTest {
     val typeRegistry = TypeScriptTypeRegistry(setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry, compiler) { document ->
+      generate(testUri, typeRegistry, compiler) { document, shapeIndex ->
         TypeScriptSundayGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           typeScriptSundayTestOptions,
         )

--- a/generator/src/test/kotlin/io/outfoxx/sunday/generator/typescript/sunday/RequestQueryParamsTest.kt
+++ b/generator/src/test/kotlin/io/outfoxx/sunday/generator/typescript/sunday/RequestQueryParamsTest.kt
@@ -44,9 +44,10 @@ class RequestQueryParamsTest {
     val typeRegistry = TypeScriptTypeRegistry(setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry, compiler) { document ->
+      generate(testUri, typeRegistry, compiler) { document, shapeIndex ->
         TypeScriptSundayGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           typeScriptSundayTestOptions,
         )
@@ -112,9 +113,10 @@ class RequestQueryParamsTest {
     val typeRegistry = TypeScriptTypeRegistry(setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry, compiler) { document ->
+      generate(testUri, typeRegistry, compiler) { document, shapeIndex ->
         TypeScriptSundayGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           typeScriptSundayTestOptions,
         )
@@ -188,9 +190,10 @@ class RequestQueryParamsTest {
     val typeRegistry = TypeScriptTypeRegistry(setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry, compiler) { document ->
+      generate(testUri, typeRegistry, compiler) { document, shapeIndex ->
         TypeScriptSundayGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           typeScriptSundayTestOptions,
         )

--- a/generator/src/test/kotlin/io/outfoxx/sunday/generator/typescript/sunday/RequestUriParamsTest.kt
+++ b/generator/src/test/kotlin/io/outfoxx/sunday/generator/typescript/sunday/RequestUriParamsTest.kt
@@ -44,9 +44,10 @@ class RequestUriParamsTest {
     val typeRegistry = TypeScriptTypeRegistry(setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry, compiler) { document ->
+      generate(testUri, typeRegistry, compiler) { document, shapeIndex ->
         TypeScriptSundayGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           typeScriptSundayTestOptions,
         )
@@ -114,9 +115,10 @@ class RequestUriParamsTest {
     val typeRegistry = TypeScriptTypeRegistry(setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry, compiler) { document ->
+      generate(testUri, typeRegistry, compiler) { document, shapeIndex ->
         TypeScriptSundayGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           typeScriptSundayTestOptions,
         )
@@ -182,9 +184,10 @@ class RequestUriParamsTest {
     val typeRegistry = TypeScriptTypeRegistry(setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry, compiler) { document ->
+      generate(testUri, typeRegistry, compiler) { document, shapeIndex ->
         TypeScriptSundayGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           typeScriptSundayTestOptions,
         )
@@ -260,9 +263,10 @@ class RequestUriParamsTest {
     val typeRegistry = TypeScriptTypeRegistry(setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry, compiler) { document ->
+      generate(testUri, typeRegistry, compiler) { document, shapeIndex ->
         TypeScriptSundayGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           typeScriptSundayTestOptions,
         )

--- a/generator/src/test/kotlin/io/outfoxx/sunday/generator/typescript/sunday/ResponseBodyContentTest.kt
+++ b/generator/src/test/kotlin/io/outfoxx/sunday/generator/typescript/sunday/ResponseBodyContentTest.kt
@@ -44,9 +44,10 @@ class ResponseBodyContentTest {
     val typeRegistry = TypeScriptTypeRegistry(setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry, compiler) { document ->
+      generate(testUri, typeRegistry, compiler) { document, shapeIndex ->
         TypeScriptSundayGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           typeScriptSundayTestOptions,
         )
@@ -107,9 +108,10 @@ class ResponseBodyContentTest {
     val typeRegistry = TypeScriptTypeRegistry(setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry, compiler) { document ->
+      generate(testUri, typeRegistry, compiler) { document, shapeIndex ->
         TypeScriptSundayGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           typeScriptSundayTestOptions,
         )
@@ -169,9 +171,10 @@ class ResponseBodyContentTest {
     val typeRegistry = TypeScriptTypeRegistry(setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry, compiler) { document ->
+      generate(testUri, typeRegistry, compiler) { document, shapeIndex ->
         TypeScriptSundayGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           typeScriptSundayTestOptions,
         )
@@ -259,9 +262,10 @@ class ResponseBodyContentTest {
     val typeRegistry = TypeScriptTypeRegistry(setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry, compiler) { document ->
+      generate(testUri, typeRegistry, compiler) { document, shapeIndex ->
         TypeScriptSundayGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           typeScriptSundayTestOptions,
         )

--- a/generator/src/test/kotlin/io/outfoxx/sunday/generator/typescript/sunday/ResponseEventsTest.kt
+++ b/generator/src/test/kotlin/io/outfoxx/sunday/generator/typescript/sunday/ResponseEventsTest.kt
@@ -44,9 +44,10 @@ class ResponseEventsTest {
     val typeRegistry = TypeScriptTypeRegistry(setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry, compiler) { document ->
+      generate(testUri, typeRegistry, compiler) { document, shapeIndex ->
         TypeScriptSundayGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           typeScriptSundayTestOptions,
         )
@@ -102,9 +103,10 @@ class ResponseEventsTest {
     val typeRegistry = TypeScriptTypeRegistry(setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry, compiler) { document ->
+      generate(testUri, typeRegistry, compiler) { document, shapeIndex ->
         TypeScriptSundayGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           typeScriptSundayTestOptions,
         )
@@ -185,9 +187,10 @@ class ResponseEventsTest {
     val typeRegistry = TypeScriptTypeRegistry(setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry, compiler) { document ->
+      generate(testUri, typeRegistry, compiler) { document, shapeIndex ->
         TypeScriptSundayGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           typeScriptSundayTestOptions,
         )

--- a/generator/src/test/kotlin/io/outfoxx/sunday/generator/typescript/sunday/ResponseProblemsTest.kt
+++ b/generator/src/test/kotlin/io/outfoxx/sunday/generator/typescript/sunday/ResponseProblemsTest.kt
@@ -47,9 +47,10 @@ class ResponseProblemsTest {
     val typeRegistry = TypeScriptTypeRegistry(setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry, compiler) { document ->
+      generate(testUri, typeRegistry, compiler) { document, shapeIndex ->
         TypeScriptSundayGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           typeScriptSundayTestOptions,
         )
@@ -114,9 +115,10 @@ class ResponseProblemsTest {
     val typeRegistry = TypeScriptTypeRegistry(setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry, compiler) { document ->
+      generate(testUri, typeRegistry, compiler) { document, shapeIndex ->
         TypeScriptSundayGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           typeScriptSundayTestOptions,
         )
@@ -177,9 +179,10 @@ class ResponseProblemsTest {
     val typeRegistry = TypeScriptTypeRegistry(setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry, compiler) { document ->
+      generate(testUri, typeRegistry, compiler) { document, shapeIndex ->
         TypeScriptSundayGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           typeScriptSundayTestOptions,
         )
@@ -231,9 +234,10 @@ class ResponseProblemsTest {
     val typeRegistry = TypeScriptTypeRegistry(setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry, compiler) { document ->
+      generate(testUri, typeRegistry, compiler) { document, shapeIndex ->
         TypeScriptSundayGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           typeScriptSundayTestOptions,
         )
@@ -285,9 +289,10 @@ class ResponseProblemsTest {
     val typeRegistry = TypeScriptTypeRegistry(setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry, compiler) { document ->
+      generate(testUri, typeRegistry, compiler) { document, shapeIndex ->
         TypeScriptSundayGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           typeScriptSundayTestOptions,
         )
@@ -339,9 +344,10 @@ class ResponseProblemsTest {
     val typeRegistry = TypeScriptTypeRegistry(setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry, compiler) { document ->
+      generate(testUri, typeRegistry, compiler) { document, shapeIndex ->
         TypeScriptSundayGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           typeScriptSundayTestOptions,
         )
@@ -393,9 +399,10 @@ class ResponseProblemsTest {
     val typeRegistry = TypeScriptTypeRegistry(setOf())
 
     val builtTypes =
-      generate(testUri, typeRegistry, compiler) { document ->
+      generate(testUri, typeRegistry, compiler) { document, shapeIndex ->
         TypeScriptSundayGenerator(
           document,
+          shapeIndex,
           typeRegistry,
           typeScriptSundayTestOptions,
         )

--- a/generator/src/test/kotlin/io/outfoxx/sunday/generator/typescript/tools/generator.kt
+++ b/generator/src/test/kotlin/io/outfoxx/sunday/generator/typescript/tools/generator.kt
@@ -16,8 +16,9 @@
 
 package io.outfoxx.sunday.generator.typescript.tools
 
-import amf.client.model.document.Document
+import amf.core.client.platform.model.document.Document
 import io.outfoxx.sunday.generator.GenerationMode.Client
+import io.outfoxx.sunday.generator.common.ShapeIndex
 import io.outfoxx.sunday.generator.typescript.TypeScriptGenerator
 import io.outfoxx.sunday.generator.typescript.TypeScriptResolutionContext
 import io.outfoxx.sunday.generator.typescript.TypeScriptTypeRegistry
@@ -45,13 +46,13 @@ fun generateTypes(
   includeIndex: Boolean = false
 ): Map<TypeName.Standard, ModuleSpec> {
 
-  val document = TestAPIProcessing.process(uri).document
+  val (document, shapeIndex) = TestAPIProcessing.process(uri)
 
   val apiTypeName = TypeName.namedImport("API", "!api")
   typeRegistry.addServiceType(apiTypeName, ClassSpec.builder(apiTypeName))
 
-  TestAPIProcessing.generateTypes(document, Client, typeRegistry::defineProblemType) { name, schema ->
-    val context = TypeScriptResolutionContext(document, apiTypeName.nested(name))
+  TestAPIProcessing.generateTypes(document, shapeIndex, Client, typeRegistry::defineProblemType) { name, schema ->
+    val context = TypeScriptResolutionContext(document, shapeIndex, apiTypeName.nested(name))
     typeRegistry.resolveTypeName(schema, context)
   }
 
@@ -66,12 +67,12 @@ fun generate(
   uri: URI,
   typeRegistry: TypeScriptTypeRegistry,
   compiler: TypeScriptCompiler,
-  generatorFactory: (Document) -> TypeScriptGenerator
+  generatorFactory: (Document, ShapeIndex) -> TypeScriptGenerator
 ): Map<TypeName.Standard, ModuleSpec> {
 
-  val document = TestAPIProcessing.process(uri).document
+  val (document, shapeIndex) = TestAPIProcessing.process(uri)
 
-  val generator = generatorFactory(document)
+  val generator = generatorFactory(document, shapeIndex)
 
   generator.generateServiceTypes()
 

--- a/generator/src/test/kotlin/io/outfoxx/sunday/generator/utils/TestAPIProcessing.kt
+++ b/generator/src/test/kotlin/io/outfoxx/sunday/generator/utils/TestAPIProcessing.kt
@@ -16,14 +16,15 @@
 
 package io.outfoxx.sunday.generator.utils
 
-import amf.client.model.document.Document
-import amf.client.model.domain.ObjectNode
-import amf.client.model.domain.Shape
+import amf.core.client.platform.model.document.Document
+import amf.core.client.platform.model.domain.ObjectNode
+import amf.core.client.platform.model.domain.Shape
 import com.damnhandy.uri.template.UriTemplate
 import io.outfoxx.sunday.generator.APIAnnotationName
 import io.outfoxx.sunday.generator.GenerationMode
 import io.outfoxx.sunday.generator.ProblemTypeDefinition
 import io.outfoxx.sunday.generator.common.APIProcessor
+import io.outfoxx.sunday.generator.common.ShapeIndex
 import org.junit.jupiter.api.fail
 import java.net.URI
 
@@ -47,8 +48,9 @@ object TestAPIProcessing : APIProcessor() {
 
   fun generateTypes(
     document: Document,
+    shapeIndex: ShapeIndex,
     mode: GenerationMode,
-    problemTypeHandler: (String, ProblemTypeDefinition) -> Unit,
+    problemTypeHandler: (String, ProblemTypeDefinition, ShapeIndex) -> Unit,
     typeHandler: (name: String, shape: Shape) -> Unit
   ) {
 
@@ -96,7 +98,7 @@ object TestAPIProcessing : APIProcessor() {
     problemTypesAnn?.properties()?.forEach { (problemCode, problemDef) ->
       val problemType =
         ProblemTypeDefinition(problemCode, problemDef as ObjectNode, URI(problemBaseUri), document, problemDef)
-      problemTypeHandler(problemCode, problemType)
+      problemTypeHandler(problemCode, problemType, shapeIndex)
     }
   }
 }

--- a/generator/src/test/resources/raml/test-overlay.raml
+++ b/generator/src/test/resources/raml/test-overlay.raml
@@ -6,5 +6,4 @@ annotationTypes:
 
 /test/{id}:
   get:
-    displayName: fetch
     (test-ann): true

--- a/generator/src/test/resources/raml/test.raml
+++ b/generator/src/test/resources/raml/test.raml
@@ -88,7 +88,7 @@ types:
   get:
     displayName: list
 
-  /test2/{id}:
+  /{id}:
     get:
       displayName: fetch
       body:

--- a/gradle-plugin/src/main/kotlin/io/outfoxx/sunday/generator/gradle/SundayGenerate.kt
+++ b/gradle-plugin/src/main/kotlin/io/outfoxx/sunday/generator/gradle/SundayGenerate.kt
@@ -213,6 +213,7 @@ open class SundayGenerate
           TargetFramework.JAXRS ->
             KotlinJAXRSGenerator(
               processed.document,
+              processed.shapeIndex,
               typeRegistry,
               KotlinJAXRSGenerator.Options(
                 coroutines.orNull ?: false,
@@ -230,6 +231,7 @@ open class SundayGenerate
           TargetFramework.Sunday ->
             KotlinSundayGenerator(
               processed.document,
+              processed.shapeIndex,
               typeRegistry,
               KotlinGenerator.Options(
                 servicePkgName,

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,10 +2,10 @@ org.gradle.jvmargs=-XX:MaxMetaspaceSize=1g
 
 releaseVersion=2.0.0-SNAPSHOT
 
-kotlinPluginVersion=1.5.31
+kotlinPluginVersion=1.7.20
 jibPluginVersion=3.1.4
 shadowPluginVersion=7.1.0
-dokkaPluginVersion=1.5.31
+dokkaPluginVersion=1.7.20
 licenserPluginVersion=0.6.1
 kotlinterPluginVersion=3.3.0
 pluginPublishPluginVersion=1.0.0-rc-3
@@ -29,7 +29,7 @@ mutinyVersion=0.17.0
 rxJava3Version=3.0.13
 rxJava2Version=2.2.21
 
-amfClientVersion=4.7.8
+amfClientVersion=5.2.0
 cliktVersion=3.1.0
 kotlinPoetVersion=1.8.0
 typeScriptPoetVersion=1.1.2


### PR DESCRIPTION
Adds support for RAML overlays & extensions by creating a `ShapeIndex` that records all the necessary information that is lost during resolution.

Additionally, all resolution and lookups have been moved to the `ResolutionContext` itself and generators are required to use it instead of directly attempting these operations, ensuring the index is used when required.

Finally, the AMF and Kotln versions have been updated to the latest versions to ensure the vastly different new code targets the latest APIs.