### PR TITLE
Remove redundant warning about multiple media types for JAX-RS clients

### DIFF
--- a/generator/src/main/kotlin/io/outfoxx/sunday/generator/kotlin/KotlinJAXRSGenerator.kt
+++ b/generator/src/main/kotlin/io/outfoxx/sunday/generator/kotlin/KotlinJAXRSGenerator.kt
@@ -203,13 +203,6 @@ class KotlinJAXRSGenerator(
 
     if (defaultMediaTypes.isNotEmpty()) {
 
-      if (defaultMediaTypes.size > 1 && generationMode == Client) {
-        println(
-          "[WARN] Using multiple default media types for a JAX-RS client is not supported, " +
-            "the first value will be chosen",
-        )
-      }
-
       val prodAnn = AnnotationSpec.builder(Produces::class)
         .addMember("value = [%L]", defaultMediaTypes.joinToString(",") { "\"$it\"" })
         .build()


### PR DESCRIPTION
The message was incorrect, as multiple types are allowed for @Produces, just not @Consumes. This is essentially how all the clients work and the reason for allowing reordering via `defaultMediaTypes`.