### PR TITLE
Switch to AdoptOpenJDK java distribution for CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     - uses: actions/setup-java@v3
       with:
         java-version: '17'
-        distribution: oracle
+        distribution: adopt
 
     - name: Select Xcode
       run: sudo xcode-select -s /Applications/Xcode_14.1.app/Contents/Developer

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -22,7 +22,7 @@ jobs:
     - uses: actions/setup-java@v3
       with:
         java-version: '17'
-        distribution: oracle
+        distribution: adopt
 
     - name: Build Artifacts & Documentation
       uses: burrunan/gradle-cache-action@v1

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           java-version: '17'
-          distribution: oracle
+          distribution: adopt
 
       - name: Build Artifacts & Documentation
         uses: burrunan/gradle-cache-action@v1


### PR DESCRIPTION
`oracle` support has been removed from `actions/setup-java`