### PR TITLE
Fix nullify methods with result responses

### DIFF
--- a/generator/src/main/kotlin/io/outfoxx/sunday/generator/kotlin/KotlinJAXRSGenerator.kt
+++ b/generator/src/main/kotlin/io/outfoxx/sunday/generator/kotlin/KotlinJAXRSGenerator.kt
@@ -592,7 +592,7 @@ class KotlinJAXRSGenerator(
             .build(),
         )
       }
-    } else {
+    } else if (!options.alwaysUseResponseReturn) {
       addNullifyMethod(operation, functionBuilder.build(), problemTypes, typeBuilder)
     }
 

--- a/generator/src/main/kotlin/io/outfoxx/sunday/generator/swift/SwiftSundayGenerator.kt
+++ b/generator/src/main/kotlin/io/outfoxx/sunday/generator/swift/SwiftSundayGenerator.kt
@@ -612,6 +612,9 @@ class SwiftSundayGenerator(
     val returnType = function.returnType
     val returnTypeOptional =
       when {
+        returnType is ParameterizedTypeName && returnType.rawType == RESULT_RESPONSE ->
+          returnType.makeOptional()
+
         returnType is ParameterizedTypeName && returnType.typeArguments.size == 1 ->
           returnType.rawType.parameterizedBy(returnType.typeArguments[0].makeOptional())
 

--- a/generator/src/test/kotlin/io/outfoxx/sunday/generator/kotlin/jaxrs/RequestCoroutineMethodsTest.kt
+++ b/generator/src/test/kotlin/io/outfoxx/sunday/generator/kotlin/jaxrs/RequestCoroutineMethodsTest.kt
@@ -191,20 +191,79 @@ class RequestCoroutineMethodsTest {
         @Produces(value = ["application/json"])
         @Consumes(value = ["application/json"])
         public interface API {
-          public suspend fun fetchTestOrNull(limit: Int): Test? = try {
-            fetchTest(limit)
+          public suspend fun fetchTest1OrNull(limit: Int): Test? = try {
+            fetchTest1(limit)
+          } catch(x: TestNotFoundProblem) {
+            null
+          } catch(x: AnotherNotFoundProblem) {
+            null
           } catch(x: ThrowableProblem) {
-            when {
-              x is TestNotFoundProblem -> null
-              x is AnotherNotFoundProblem -> null
-              x.status?.statusCode == 404 || x.status?.statusCode == 405 -> null
+            when (x.status?.statusCode) {
+              404, 405 -> null
               else -> throw x
             }
           }
 
           @GET
-          @Path(value = "/tests")
-          public suspend fun fetchTest(@QueryParam(value = "limit") limit: Int): Test
+          @Path(value = "/test1")
+          public suspend fun fetchTest1(@QueryParam(value = "limit") limit: Int): Test
+
+          public suspend fun fetchTest2OrNull(limit: Int): Test? = try {
+            fetchTest2(limit)
+          } catch(x: TestNotFoundProblem) {
+            null
+          } catch(x: AnotherNotFoundProblem) {
+            null
+          } catch(x: ThrowableProblem) {
+            if (x.status?.statusCode == 404) {
+              null
+            } else {
+              throw x
+            }
+          }
+
+          @GET
+          @Path(value = "/test2")
+          public suspend fun fetchTest2(@QueryParam(value = "limit") limit: Int): Test
+
+          public suspend fun fetchTest3OrNull(limit: Int): Test? = try {
+            fetchTest3(limit)
+          } catch(x: TestNotFoundProblem) {
+            null
+          } catch(x: AnotherNotFoundProblem) {
+            null
+          }
+
+          @GET
+          @Path(value = "/test3")
+          public suspend fun fetchTest3(@QueryParam(value = "limit") limit: Int): Test
+
+          public suspend fun fetchTest4OrNull(limit: Int): Test? = try {
+            fetchTest4(limit)
+          } catch(x: ThrowableProblem) {
+            when (x.status?.statusCode) {
+              404, 405 -> null
+              else -> throw x
+            }
+          }
+
+          @GET
+          @Path(value = "/test4")
+          public suspend fun fetchTest4(@QueryParam(value = "limit") limit: Int): Test
+
+          public suspend fun fetchTest5OrNull(limit: Int): Test? = try {
+            fetchTest5(limit)
+          } catch(x: ThrowableProblem) {
+            if (x.status?.statusCode == 404) {
+              null
+            } else {
+              throw x
+            }
+          }
+
+          @GET
+          @Path(value = "/test5")
+          public suspend fun fetchTest5(@QueryParam(value = "limit") limit: Int): Test
         }
 
       """.trimIndent(),
@@ -263,7 +322,7 @@ class RequestCoroutineMethodsTest {
           @Path(value = "/test1")
           @Produces(value = ["text/event-stream"])
           public suspend fun fetchEventsSimple(): Flow<Test1>
-  
+
           @GET
           @Path(value = "/test2")
           @Produces(value = ["text/event-stream"])

--- a/generator/src/test/kotlin/io/outfoxx/sunday/generator/kotlin/jaxrs/RequestReactiveMethodsTest.kt
+++ b/generator/src/test/kotlin/io/outfoxx/sunday/generator/kotlin/jaxrs/RequestReactiveMethodsTest.kt
@@ -196,11 +196,11 @@ class RequestReactiveMethodsTest {
         import javax.ws.rs.QueryParam
         import kotlin.Int
         import org.zalando.problem.ThrowableProblem
-        
+
         @Produces(value = ["application/json"])
         @Consumes(value = ["application/json"])
         public interface API {
-          public fun fetchTestOrNull(limit: Int): CompletionStage<Test?> = fetchTest(limit)
+          public fun fetchTest1OrNull(limit: Int): CompletionStage<Test?> = fetchTest1(limit)
             .exceptionally { x ->
               when {
                 x is TestNotFoundProblem -> null
@@ -212,8 +212,60 @@ class RequestReactiveMethodsTest {
             }
 
           @GET
-          @Path(value = "/tests")
-          public fun fetchTest(@QueryParam(value = "limit") limit: Int): CompletionStage<Test>
+          @Path(value = "/test1")
+          public fun fetchTest1(@QueryParam(value = "limit") limit: Int): CompletionStage<Test>
+
+          public fun fetchTest2OrNull(limit: Int): CompletionStage<Test?> = fetchTest2(limit)
+            .exceptionally { x ->
+              when {
+                x is TestNotFoundProblem -> null
+                x is AnotherNotFoundProblem -> null
+                x is ThrowableProblem && x.status?.statusCode == 404 -> null
+                else -> throw x
+              }
+            }
+
+          @GET
+          @Path(value = "/test2")
+          public fun fetchTest2(@QueryParam(value = "limit") limit: Int): CompletionStage<Test>
+
+          public fun fetchTest3OrNull(limit: Int): CompletionStage<Test?> = fetchTest3(limit)
+            .exceptionally { x ->
+              when {
+                x is TestNotFoundProblem -> null
+                x is AnotherNotFoundProblem -> null
+                else -> throw x
+              }
+            }
+
+          @GET
+          @Path(value = "/test3")
+          public fun fetchTest3(@QueryParam(value = "limit") limit: Int): CompletionStage<Test>
+
+          public fun fetchTest4OrNull(limit: Int): CompletionStage<Test?> = fetchTest4(limit)
+            .exceptionally { x ->
+              when {
+                x is ThrowableProblem && (x.status?.statusCode == 404 || x.status?.statusCode == 405) ->
+                    null
+                else -> throw x
+              }
+            }
+
+          @GET
+          @Path(value = "/test4")
+          public fun fetchTest4(@QueryParam(value = "limit") limit: Int): CompletionStage<Test>
+
+          public fun fetchTest5OrNull(limit: Int): CompletionStage<Test?> = fetchTest5(limit)
+            .exceptionally { x ->
+              when {
+                x is ThrowableProblem && x.status?.statusCode == 404 -> null
+                else -> throw x
+              }
+            }
+
+          @GET
+          @Path(value = "/test5")
+          public fun fetchTest5(@QueryParam(value = "limit") limit: Int): CompletionStage<Test>
         }
 
       """.trimIndent(),
@@ -268,11 +320,11 @@ class RequestReactiveMethodsTest {
         import javax.ws.rs.QueryParam
         import kotlin.Int
         import org.zalando.problem.ThrowableProblem
-        
+
         @Produces(value = ["application/json"])
         @Consumes(value = ["application/json"])
         public interface API {
-          public fun fetchTestOrNull(limit: Int): Uni<Test?> = fetchTest(limit)
+          public fun fetchTest1OrNull(limit: Int): Uni<Test?> = fetchTest1(limit)
             .onFailure().recoverWithItem { x ->
               when {
                 x is TestNotFoundProblem -> null
@@ -284,8 +336,60 @@ class RequestReactiveMethodsTest {
             }
 
           @GET
-          @Path(value = "/tests")
-          public fun fetchTest(@QueryParam(value = "limit") limit: Int): Uni<Test>
+          @Path(value = "/test1")
+          public fun fetchTest1(@QueryParam(value = "limit") limit: Int): Uni<Test>
+
+          public fun fetchTest2OrNull(limit: Int): Uni<Test?> = fetchTest2(limit)
+            .onFailure().recoverWithItem { x ->
+              when {
+                x is TestNotFoundProblem -> null
+                x is AnotherNotFoundProblem -> null
+                x is ThrowableProblem && x.status?.statusCode == 404 -> null
+                else -> throw x
+              }
+            }
+
+          @GET
+          @Path(value = "/test2")
+          public fun fetchTest2(@QueryParam(value = "limit") limit: Int): Uni<Test>
+
+          public fun fetchTest3OrNull(limit: Int): Uni<Test?> = fetchTest3(limit)
+            .onFailure().recoverWithItem { x ->
+              when {
+                x is TestNotFoundProblem -> null
+                x is AnotherNotFoundProblem -> null
+                else -> throw x
+              }
+            }
+
+          @GET
+          @Path(value = "/test3")
+          public fun fetchTest3(@QueryParam(value = "limit") limit: Int): Uni<Test>
+
+          public fun fetchTest4OrNull(limit: Int): Uni<Test?> = fetchTest4(limit)
+            .onFailure().recoverWithItem { x ->
+              when {
+                x is ThrowableProblem && (x.status?.statusCode == 404 || x.status?.statusCode == 405) ->
+                    null
+                else -> throw x
+              }
+            }
+
+          @GET
+          @Path(value = "/test4")
+          public fun fetchTest4(@QueryParam(value = "limit") limit: Int): Uni<Test>
+
+          public fun fetchTest5OrNull(limit: Int): Uni<Test?> = fetchTest5(limit)
+            .onFailure().recoverWithItem { x ->
+              when {
+                x is ThrowableProblem && x.status?.statusCode == 404 -> null
+                else -> throw x
+              }
+            }
+
+          @GET
+          @Path(value = "/test5")
+          public fun fetchTest5(@QueryParam(value = "limit") limit: Int): Uni<Test>
         }
 
       """.trimIndent(),
@@ -341,11 +445,11 @@ class RequestReactiveMethodsTest {
         import javax.ws.rs.QueryParam
         import kotlin.Int
         import org.zalando.problem.ThrowableProblem
-        
+
         @Produces(value = ["application/json"])
         @Consumes(value = ["application/json"])
         public interface API {
-          public fun fetchTestOrNull(limit: Int): Single<Optional<Test>> = fetchTest(limit)
+          public fun fetchTest1OrNull(limit: Int): Single<Optional<Test>> = fetchTest1(limit)
             .map { Optional.of(it) }
             .onErrorReturn { x ->
               when {
@@ -358,8 +462,64 @@ class RequestReactiveMethodsTest {
             }
 
           @GET
-          @Path(value = "/tests")
-          public fun fetchTest(@QueryParam(value = "limit") limit: Int): Single<Test>
+          @Path(value = "/test1")
+          public fun fetchTest1(@QueryParam(value = "limit") limit: Int): Single<Test>
+
+          public fun fetchTest2OrNull(limit: Int): Single<Optional<Test>> = fetchTest2(limit)
+            .map { Optional.of(it) }
+            .onErrorReturn { x ->
+              when {
+                x is TestNotFoundProblem -> Optional.empty()
+                x is AnotherNotFoundProblem -> Optional.empty()
+                x is ThrowableProblem && x.status?.statusCode == 404 -> Optional.empty()
+                else -> throw x
+              }
+            }
+
+          @GET
+          @Path(value = "/test2")
+          public fun fetchTest2(@QueryParam(value = "limit") limit: Int): Single<Test>
+
+          public fun fetchTest3OrNull(limit: Int): Single<Optional<Test>> = fetchTest3(limit)
+            .map { Optional.of(it) }
+            .onErrorReturn { x ->
+              when {
+                x is TestNotFoundProblem -> Optional.empty()
+                x is AnotherNotFoundProblem -> Optional.empty()
+                else -> throw x
+              }
+            }
+
+          @GET
+          @Path(value = "/test3")
+          public fun fetchTest3(@QueryParam(value = "limit") limit: Int): Single<Test>
+
+          public fun fetchTest4OrNull(limit: Int): Single<Optional<Test>> = fetchTest4(limit)
+            .map { Optional.of(it) }
+            .onErrorReturn { x ->
+              when {
+                x is ThrowableProblem && (x.status?.statusCode == 404 || x.status?.statusCode == 405) ->
+                    Optional.empty()
+                else -> throw x
+              }
+            }
+
+          @GET
+          @Path(value = "/test4")
+          public fun fetchTest4(@QueryParam(value = "limit") limit: Int): Single<Test>
+
+          public fun fetchTest5OrNull(limit: Int): Single<Optional<Test>> = fetchTest5(limit)
+            .map { Optional.of(it) }
+            .onErrorReturn { x ->
+              when {
+                x is ThrowableProblem && x.status?.statusCode == 404 -> Optional.empty()
+                else -> throw x
+              }
+            }
+
+          @GET
+          @Path(value = "/test5")
+          public fun fetchTest5(@QueryParam(value = "limit") limit: Int): Single<Test>
         }
 
       """.trimIndent(),
@@ -415,11 +575,11 @@ class RequestReactiveMethodsTest {
         import javax.ws.rs.QueryParam
         import kotlin.Int
         import org.zalando.problem.ThrowableProblem
-        
+
         @Produces(value = ["application/json"])
         @Consumes(value = ["application/json"])
         public interface API {
-          public fun fetchTestOrNull(limit: Int): Observable<Optional<Test>> = fetchTest(limit)
+          public fun fetchTest1OrNull(limit: Int): Observable<Optional<Test>> = fetchTest1(limit)
             .map { Optional.of(it) }
             .onErrorReturn { x ->
               when {
@@ -432,8 +592,64 @@ class RequestReactiveMethodsTest {
             }
 
           @GET
-          @Path(value = "/tests")
-          public fun fetchTest(@QueryParam(value = "limit") limit: Int): Observable<Test>
+          @Path(value = "/test1")
+          public fun fetchTest1(@QueryParam(value = "limit") limit: Int): Observable<Test>
+
+          public fun fetchTest2OrNull(limit: Int): Observable<Optional<Test>> = fetchTest2(limit)
+            .map { Optional.of(it) }
+            .onErrorReturn { x ->
+              when {
+                x is TestNotFoundProblem -> Optional.empty()
+                x is AnotherNotFoundProblem -> Optional.empty()
+                x is ThrowableProblem && x.status?.statusCode == 404 -> Optional.empty()
+                else -> throw x
+              }
+            }
+
+          @GET
+          @Path(value = "/test2")
+          public fun fetchTest2(@QueryParam(value = "limit") limit: Int): Observable<Test>
+
+          public fun fetchTest3OrNull(limit: Int): Observable<Optional<Test>> = fetchTest3(limit)
+            .map { Optional.of(it) }
+            .onErrorReturn { x ->
+              when {
+                x is TestNotFoundProblem -> Optional.empty()
+                x is AnotherNotFoundProblem -> Optional.empty()
+                else -> throw x
+              }
+            }
+
+          @GET
+          @Path(value = "/test3")
+          public fun fetchTest3(@QueryParam(value = "limit") limit: Int): Observable<Test>
+
+          public fun fetchTest4OrNull(limit: Int): Observable<Optional<Test>> = fetchTest4(limit)
+            .map { Optional.of(it) }
+            .onErrorReturn { x ->
+              when {
+                x is ThrowableProblem && (x.status?.statusCode == 404 || x.status?.statusCode == 405) ->
+                    Optional.empty()
+                else -> throw x
+              }
+            }
+
+          @GET
+          @Path(value = "/test4")
+          public fun fetchTest4(@QueryParam(value = "limit") limit: Int): Observable<Test>
+
+          public fun fetchTest5OrNull(limit: Int): Observable<Optional<Test>> = fetchTest5(limit)
+            .map { Optional.of(it) }
+            .onErrorReturn { x ->
+              when {
+                x is ThrowableProblem && x.status?.statusCode == 404 -> Optional.empty()
+                else -> throw x
+              }
+            }
+
+          @GET
+          @Path(value = "/test5")
+          public fun fetchTest5(@QueryParam(value = "limit") limit: Int): Observable<Test>
         }
 
       """.trimIndent(),
@@ -489,11 +705,11 @@ class RequestReactiveMethodsTest {
         import javax.ws.rs.QueryParam
         import kotlin.Int
         import org.zalando.problem.ThrowableProblem
-        
+
         @Produces(value = ["application/json"])
         @Consumes(value = ["application/json"])
         public interface API {
-          public fun fetchTestOrNull(limit: Int): Single<Optional<Test>> = fetchTest(limit)
+          public fun fetchTest1OrNull(limit: Int): Single<Optional<Test>> = fetchTest1(limit)
             .map { Optional.of(it) }
             .onErrorReturn { x ->
               when {
@@ -506,8 +722,64 @@ class RequestReactiveMethodsTest {
             }
 
           @GET
-          @Path(value = "/tests")
-          public fun fetchTest(@QueryParam(value = "limit") limit: Int): Single<Test>
+          @Path(value = "/test1")
+          public fun fetchTest1(@QueryParam(value = "limit") limit: Int): Single<Test>
+
+          public fun fetchTest2OrNull(limit: Int): Single<Optional<Test>> = fetchTest2(limit)
+            .map { Optional.of(it) }
+            .onErrorReturn { x ->
+              when {
+                x is TestNotFoundProblem -> Optional.empty()
+                x is AnotherNotFoundProblem -> Optional.empty()
+                x is ThrowableProblem && x.status?.statusCode == 404 -> Optional.empty()
+                else -> throw x
+              }
+            }
+
+          @GET
+          @Path(value = "/test2")
+          public fun fetchTest2(@QueryParam(value = "limit") limit: Int): Single<Test>
+
+          public fun fetchTest3OrNull(limit: Int): Single<Optional<Test>> = fetchTest3(limit)
+            .map { Optional.of(it) }
+            .onErrorReturn { x ->
+              when {
+                x is TestNotFoundProblem -> Optional.empty()
+                x is AnotherNotFoundProblem -> Optional.empty()
+                else -> throw x
+              }
+            }
+
+          @GET
+          @Path(value = "/test3")
+          public fun fetchTest3(@QueryParam(value = "limit") limit: Int): Single<Test>
+
+          public fun fetchTest4OrNull(limit: Int): Single<Optional<Test>> = fetchTest4(limit)
+            .map { Optional.of(it) }
+            .onErrorReturn { x ->
+              when {
+                x is ThrowableProblem && (x.status?.statusCode == 404 || x.status?.statusCode == 405) ->
+                    Optional.empty()
+                else -> throw x
+              }
+            }
+
+          @GET
+          @Path(value = "/test4")
+          public fun fetchTest4(@QueryParam(value = "limit") limit: Int): Single<Test>
+
+          public fun fetchTest5OrNull(limit: Int): Single<Optional<Test>> = fetchTest5(limit)
+            .map { Optional.of(it) }
+            .onErrorReturn { x ->
+              when {
+                x is ThrowableProblem && x.status?.statusCode == 404 -> Optional.empty()
+                else -> throw x
+              }
+            }
+
+          @GET
+          @Path(value = "/test5")
+          public fun fetchTest5(@QueryParam(value = "limit") limit: Int): Single<Test>
         }
 
       """.trimIndent(),
@@ -563,11 +835,11 @@ class RequestReactiveMethodsTest {
         import javax.ws.rs.QueryParam
         import kotlin.Int
         import org.zalando.problem.ThrowableProblem
-        
+
         @Produces(value = ["application/json"])
         @Consumes(value = ["application/json"])
         public interface API {
-          public fun fetchTestOrNull(limit: Int): Observable<Optional<Test>> = fetchTest(limit)
+          public fun fetchTest1OrNull(limit: Int): Observable<Optional<Test>> = fetchTest1(limit)
             .map { Optional.of(it) }
             .onErrorReturn { x ->
               when {
@@ -580,8 +852,64 @@ class RequestReactiveMethodsTest {
             }
 
           @GET
-          @Path(value = "/tests")
-          public fun fetchTest(@QueryParam(value = "limit") limit: Int): Observable<Test>
+          @Path(value = "/test1")
+          public fun fetchTest1(@QueryParam(value = "limit") limit: Int): Observable<Test>
+
+          public fun fetchTest2OrNull(limit: Int): Observable<Optional<Test>> = fetchTest2(limit)
+            .map { Optional.of(it) }
+            .onErrorReturn { x ->
+              when {
+                x is TestNotFoundProblem -> Optional.empty()
+                x is AnotherNotFoundProblem -> Optional.empty()
+                x is ThrowableProblem && x.status?.statusCode == 404 -> Optional.empty()
+                else -> throw x
+              }
+            }
+
+          @GET
+          @Path(value = "/test2")
+          public fun fetchTest2(@QueryParam(value = "limit") limit: Int): Observable<Test>
+
+          public fun fetchTest3OrNull(limit: Int): Observable<Optional<Test>> = fetchTest3(limit)
+            .map { Optional.of(it) }
+            .onErrorReturn { x ->
+              when {
+                x is TestNotFoundProblem -> Optional.empty()
+                x is AnotherNotFoundProblem -> Optional.empty()
+                else -> throw x
+              }
+            }
+
+          @GET
+          @Path(value = "/test3")
+          public fun fetchTest3(@QueryParam(value = "limit") limit: Int): Observable<Test>
+
+          public fun fetchTest4OrNull(limit: Int): Observable<Optional<Test>> = fetchTest4(limit)
+            .map { Optional.of(it) }
+            .onErrorReturn { x ->
+              when {
+                x is ThrowableProblem && (x.status?.statusCode == 404 || x.status?.statusCode == 405) ->
+                    Optional.empty()
+                else -> throw x
+              }
+            }
+
+          @GET
+          @Path(value = "/test4")
+          public fun fetchTest4(@QueryParam(value = "limit") limit: Int): Observable<Test>
+
+          public fun fetchTest5OrNull(limit: Int): Observable<Optional<Test>> = fetchTest5(limit)
+            .map { Optional.of(it) }
+            .onErrorReturn { x ->
+              when {
+                x is ThrowableProblem && x.status?.statusCode == 404 -> Optional.empty()
+                else -> throw x
+              }
+            }
+
+          @GET
+          @Path(value = "/test5")
+          public fun fetchTest5(@QueryParam(value = "limit") limit: Int): Observable<Test>
         }
 
       """.trimIndent(),

--- a/generator/src/test/kotlin/io/outfoxx/sunday/generator/kotlin/sunday/RequestMethodsTest.kt
+++ b/generator/src/test/kotlin/io/outfoxx/sunday/generator/kotlin/sunday/RequestMethodsTest.kt
@@ -289,21 +289,264 @@ class RequestMethodsTest {
             requestFactory.registerProblem("http://example.com/another_not_found",
                 AnotherNotFoundProblem::class)
           }
-          public suspend fun fetchTestOrNull(limit: Int): Test? = try {
-            fetchTest(limit)
+          public suspend fun fetchTest1OrNull(limit: Int): Test? = try {
+            fetchTest1(limit)
+          } catch(x: TestNotFoundProblem) {
+            null
+          } catch(x: AnotherNotFoundProblem) {
+            null
           } catch(x: ThrowableProblem) {
-            when {
-              x is TestNotFoundProblem -> null
-              x is AnotherNotFoundProblem -> null
-              x.status?.statusCode == 404 || x.status?.statusCode == 405 -> null
+            when (x.status?.statusCode) {
+              404, 405 -> null
               else -> throw x
             }
           }
 
-          public suspend fun fetchTest(limit: Int): Test = this.requestFactory
+          public suspend fun fetchTest1(limit: Int): Test = this.requestFactory
             .result(
               method = Method.Get,
-              pathTemplate = "/tests",
+              pathTemplate = "/test1",
+              queryParameters = mapOf(
+                "limit" to limit
+              ),
+              acceptTypes = this.defaultAcceptTypes
+            )
+
+          public suspend fun fetchTest2OrNull(limit: Int): Test? = try {
+            fetchTest2(limit)
+          } catch(x: TestNotFoundProblem) {
+            null
+          } catch(x: AnotherNotFoundProblem) {
+            null
+          } catch(x: ThrowableProblem) {
+            if (x.status?.statusCode == 404) {
+              null
+            } else {
+              throw x
+            }
+          }
+
+          public suspend fun fetchTest2(limit: Int): Test = this.requestFactory
+            .result(
+              method = Method.Get,
+              pathTemplate = "/test2",
+              queryParameters = mapOf(
+                "limit" to limit
+              ),
+              acceptTypes = this.defaultAcceptTypes
+            )
+
+          public suspend fun fetchTest3OrNull(limit: Int): Test? = try {
+            fetchTest3(limit)
+          } catch(x: TestNotFoundProblem) {
+            null
+          } catch(x: AnotherNotFoundProblem) {
+            null
+          }
+
+          public suspend fun fetchTest3(limit: Int): Test = this.requestFactory
+            .result(
+              method = Method.Get,
+              pathTemplate = "/test3",
+              queryParameters = mapOf(
+                "limit" to limit
+              ),
+              acceptTypes = this.defaultAcceptTypes
+            )
+
+          public suspend fun fetchTest4OrNull(limit: Int): Test? = try {
+            fetchTest4(limit)
+          } catch(x: ThrowableProblem) {
+            when (x.status?.statusCode) {
+              404, 405 -> null
+              else -> throw x
+            }
+          }
+
+          public suspend fun fetchTest4(limit: Int): Test = this.requestFactory
+            .result(
+              method = Method.Get,
+              pathTemplate = "/test4",
+              queryParameters = mapOf(
+                "limit" to limit
+              ),
+              acceptTypes = this.defaultAcceptTypes
+            )
+
+          public suspend fun fetchTest5OrNull(limit: Int): Test? = try {
+            fetchTest5(limit)
+          } catch(x: ThrowableProblem) {
+            if (x.status?.statusCode == 404) {
+              null
+            } else {
+              throw x
+            }
+          }
+
+          public suspend fun fetchTest5(limit: Int): Test = this.requestFactory
+            .result(
+              method = Method.Get,
+              pathTemplate = "/test5",
+              queryParameters = mapOf(
+                "limit" to limit
+              ),
+              acceptTypes = this.defaultAcceptTypes
+            )
+        }
+
+      """.trimIndent(),
+      buildString {
+        FileSpec.get("io.test", typeSpec)
+          .writeTo(this)
+      },
+    )
+  }
+
+  @Test
+  fun `test request method generation with nullify and result response`(
+    @ResourceUri("raml/resource-gen/req-methods-nullify.raml") testUri: URI,
+  ) {
+
+    val typeRegistry = KotlinTypeRegistry("io.test", null, GenerationMode.Client, setOf())
+
+    val builtTypes =
+      generate(testUri, typeRegistry) { document, shapeIndex ->
+        KotlinSundayGenerator(
+          document,
+          shapeIndex,
+          typeRegistry,
+          KotlinSundayGenerator.Options(
+            true,
+            "io.test.service",
+            "http://example.com/",
+            listOf("application/json"),
+            "API",
+          ),
+        )
+      }
+
+    val typeSpec = findType("io.test.service.API", builtTypes)
+
+    assertEquals(
+      """
+        package io.test
+
+        import io.outfoxx.sunday.MediaType
+        import io.outfoxx.sunday.RequestFactory
+        import io.outfoxx.sunday.http.Method
+        import io.outfoxx.sunday.http.ResultResponse
+        import kotlin.Int
+        import kotlin.collections.List
+        import org.zalando.problem.ThrowableProblem
+
+        public class API(
+          public val requestFactory: RequestFactory,
+          public val defaultContentTypes: List<MediaType> = listOf(),
+          public val defaultAcceptTypes: List<MediaType> = listOf(MediaType.JSON),
+        ) {
+          init {
+            requestFactory.registerProblem("http://example.com/test_not_found", TestNotFoundProblem::class)
+            requestFactory.registerProblem("http://example.com/another_not_found",
+                AnotherNotFoundProblem::class)
+          }
+          public suspend fun fetchTest1OrNull(limit: Int): ResultResponse<Test>? = try {
+            fetchTest1(limit)
+          } catch(x: TestNotFoundProblem) {
+            null
+          } catch(x: AnotherNotFoundProblem) {
+            null
+          } catch(x: ThrowableProblem) {
+            when (x.status?.statusCode) {
+              404, 405 -> null
+              else -> throw x
+            }
+          }
+
+          public suspend fun fetchTest1(limit: Int): ResultResponse<Test> = this.requestFactory
+            .resultResponse(
+              method = Method.Get,
+              pathTemplate = "/test1",
+              queryParameters = mapOf(
+                "limit" to limit
+              ),
+              acceptTypes = this.defaultAcceptTypes
+            )
+
+          public suspend fun fetchTest2OrNull(limit: Int): ResultResponse<Test>? = try {
+            fetchTest2(limit)
+          } catch(x: TestNotFoundProblem) {
+            null
+          } catch(x: AnotherNotFoundProblem) {
+            null
+          } catch(x: ThrowableProblem) {
+            if (x.status?.statusCode == 404) {
+              null
+            } else {
+              throw x
+            }
+          }
+
+          public suspend fun fetchTest2(limit: Int): ResultResponse<Test> = this.requestFactory
+            .resultResponse(
+              method = Method.Get,
+              pathTemplate = "/test2",
+              queryParameters = mapOf(
+                "limit" to limit
+              ),
+              acceptTypes = this.defaultAcceptTypes
+            )
+
+          public suspend fun fetchTest3OrNull(limit: Int): ResultResponse<Test>? = try {
+            fetchTest3(limit)
+          } catch(x: TestNotFoundProblem) {
+            null
+          } catch(x: AnotherNotFoundProblem) {
+            null
+          }
+
+          public suspend fun fetchTest3(limit: Int): ResultResponse<Test> = this.requestFactory
+            .resultResponse(
+              method = Method.Get,
+              pathTemplate = "/test3",
+              queryParameters = mapOf(
+                "limit" to limit
+              ),
+              acceptTypes = this.defaultAcceptTypes
+            )
+
+          public suspend fun fetchTest4OrNull(limit: Int): ResultResponse<Test>? = try {
+            fetchTest4(limit)
+          } catch(x: ThrowableProblem) {
+            when (x.status?.statusCode) {
+              404, 405 -> null
+              else -> throw x
+            }
+          }
+
+          public suspend fun fetchTest4(limit: Int): ResultResponse<Test> = this.requestFactory
+            .resultResponse(
+              method = Method.Get,
+              pathTemplate = "/test4",
+              queryParameters = mapOf(
+                "limit" to limit
+              ),
+              acceptTypes = this.defaultAcceptTypes
+            )
+
+          public suspend fun fetchTest5OrNull(limit: Int): ResultResponse<Test>? = try {
+            fetchTest5(limit)
+          } catch(x: ThrowableProblem) {
+            if (x.status?.statusCode == 404) {
+              null
+            } else {
+              throw x
+            }
+          }
+
+          public suspend fun fetchTest5(limit: Int): ResultResponse<Test> = this.requestFactory
+            .resultResponse(
+              method = Method.Get,
+              pathTemplate = "/test5",
               queryParameters = mapOf(
                 "limit" to limit
               ),

--- a/generator/src/test/kotlin/io/outfoxx/sunday/generator/swift/sunday/RequestMethodsTest.kt
+++ b/generator/src/test/kotlin/io/outfoxx/sunday/generator/swift/sunday/RequestMethodsTest.kt
@@ -390,19 +390,292 @@ class RequestMethodsTest {
             requestFactory.registerProblem(type: "http://example.com/another_not_found", problemType: AnotherNotFoundProblem.self)
           }
 
-          public func fetchTestOrNil(limit: Int) async throws -> Test? {
+          public func fetchTest1OrNil(limit: Int) async throws -> Test? {
             return try await nilifyResponse(
                 statuses: [404, 405],
                 problemTypes: [TestNotFoundProblem.self, AnotherNotFoundProblem.self]
               ) {
-                try await fetchTest(limit: limit)
+                try await fetchTest1(limit: limit)
               }
           }
 
-          public func fetchTest(limit: Int) async throws -> Test {
+          public func fetchTest1(limit: Int) async throws -> Test {
             return try await self.requestFactory.result(
               method: .get,
-              pathTemplate: "/tests",
+              pathTemplate: "/test1",
+              pathParameters: nil,
+              queryParameters: [
+                "limit": limit
+              ],
+              body: Empty.none,
+              contentTypes: nil,
+              acceptTypes: self.defaultAcceptTypes,
+              headers: nil
+            )
+          }
+
+          public func fetchTest2OrNil(limit: Int) async throws -> Test? {
+            return try await nilifyResponse(
+                statuses: [404],
+                problemTypes: [TestNotFoundProblem.self, AnotherNotFoundProblem.self]
+              ) {
+                try await fetchTest2(limit: limit)
+              }
+          }
+
+          public func fetchTest2(limit: Int) async throws -> Test {
+            return try await self.requestFactory.result(
+              method: .get,
+              pathTemplate: "/test2",
+              pathParameters: nil,
+              queryParameters: [
+                "limit": limit
+              ],
+              body: Empty.none,
+              contentTypes: nil,
+              acceptTypes: self.defaultAcceptTypes,
+              headers: nil
+            )
+          }
+
+          public func fetchTest3OrNil(limit: Int) async throws -> Test? {
+            return try await nilifyResponse(
+                statuses: [],
+                problemTypes: [TestNotFoundProblem.self, AnotherNotFoundProblem.self]
+              ) {
+                try await fetchTest3(limit: limit)
+              }
+          }
+
+          public func fetchTest3(limit: Int) async throws -> Test {
+            return try await self.requestFactory.result(
+              method: .get,
+              pathTemplate: "/test3",
+              pathParameters: nil,
+              queryParameters: [
+                "limit": limit
+              ],
+              body: Empty.none,
+              contentTypes: nil,
+              acceptTypes: self.defaultAcceptTypes,
+              headers: nil
+            )
+          }
+
+          public func fetchTest4OrNil(limit: Int) async throws -> Test? {
+            return try await nilifyResponse(
+                statuses: [404, 405],
+                problemTypes: []
+              ) {
+                try await fetchTest4(limit: limit)
+              }
+          }
+
+          public func fetchTest4(limit: Int) async throws -> Test {
+            return try await self.requestFactory.result(
+              method: .get,
+              pathTemplate: "/test4",
+              pathParameters: nil,
+              queryParameters: [
+                "limit": limit
+              ],
+              body: Empty.none,
+              contentTypes: nil,
+              acceptTypes: self.defaultAcceptTypes,
+              headers: nil
+            )
+          }
+
+          public func fetchTest5OrNil(limit: Int) async throws -> Test? {
+            return try await nilifyResponse(
+                statuses: [404],
+                problemTypes: []
+              ) {
+                try await fetchTest5(limit: limit)
+              }
+          }
+
+          public func fetchTest5(limit: Int) async throws -> Test {
+            return try await self.requestFactory.result(
+              method: .get,
+              pathTemplate: "/test5",
+              pathParameters: nil,
+              queryParameters: [
+                "limit": limit
+              ],
+              body: Empty.none,
+              contentTypes: nil,
+              acceptTypes: self.defaultAcceptTypes,
+              headers: nil
+            )
+          }
+
+        }
+
+      """.trimIndent(),
+      buildString {
+        FileSpec.get("", typeSpec)
+          .writeTo(this)
+      },
+    )
+  }
+
+  @Test
+  fun `test request method generation with nullify and result response`(
+    compiler: SwiftCompiler,
+    @ResourceUri("raml/resource-gen/req-methods-nullify.raml") testUri: URI,
+  ) {
+
+    val typeRegistry = SwiftTypeRegistry(setOf())
+
+    val builtTypes =
+      generate(testUri, typeRegistry, compiler) { document, shapeIndex ->
+        SwiftSundayGenerator(
+          document,
+          shapeIndex,
+          typeRegistry,
+          SwiftSundayGenerator.Options(
+            true,
+            "http://example.com/",
+            listOf("application/json"),
+            "API",
+          ),
+        )
+      }
+
+    val typeSpec = findType("API", builtTypes)
+
+    assertEquals(
+      """
+        import Sunday
+
+        public class API {
+
+          public let requestFactory: RequestFactory
+          public let defaultContentTypes: [MediaType]
+          public let defaultAcceptTypes: [MediaType]
+
+          public init(
+            requestFactory: RequestFactory,
+            defaultContentTypes: [MediaType] = [],
+            defaultAcceptTypes: [MediaType] = [.json]
+          ) {
+            self.requestFactory = requestFactory
+            self.defaultContentTypes = defaultContentTypes
+            self.defaultAcceptTypes = defaultAcceptTypes
+            requestFactory.registerProblem(type: "http://example.com/test_not_found", problemType: TestNotFoundProblem.self)
+            requestFactory.registerProblem(type: "http://example.com/another_not_found", problemType: AnotherNotFoundProblem.self)
+          }
+
+          public func fetchTest1OrNil(limit: Int) async throws -> ResultResponse<Test>? {
+            return try await nilifyResponse(
+                statuses: [404, 405],
+                problemTypes: [TestNotFoundProblem.self, AnotherNotFoundProblem.self]
+              ) {
+                try await fetchTest1(limit: limit)
+              }
+          }
+
+          public func fetchTest1(limit: Int) async throws -> ResultResponse<Test> {
+            return try await self.requestFactory.resultResponse(
+              method: .get,
+              pathTemplate: "/test1",
+              pathParameters: nil,
+              queryParameters: [
+                "limit": limit
+              ],
+              body: Empty.none,
+              contentTypes: nil,
+              acceptTypes: self.defaultAcceptTypes,
+              headers: nil
+            )
+          }
+
+          public func fetchTest2OrNil(limit: Int) async throws -> ResultResponse<Test>? {
+            return try await nilifyResponse(
+                statuses: [404],
+                problemTypes: [TestNotFoundProblem.self, AnotherNotFoundProblem.self]
+              ) {
+                try await fetchTest2(limit: limit)
+              }
+          }
+
+          public func fetchTest2(limit: Int) async throws -> ResultResponse<Test> {
+            return try await self.requestFactory.resultResponse(
+              method: .get,
+              pathTemplate: "/test2",
+              pathParameters: nil,
+              queryParameters: [
+                "limit": limit
+              ],
+              body: Empty.none,
+              contentTypes: nil,
+              acceptTypes: self.defaultAcceptTypes,
+              headers: nil
+            )
+          }
+
+          public func fetchTest3OrNil(limit: Int) async throws -> ResultResponse<Test>? {
+            return try await nilifyResponse(
+                statuses: [],
+                problemTypes: [TestNotFoundProblem.self, AnotherNotFoundProblem.self]
+              ) {
+                try await fetchTest3(limit: limit)
+              }
+          }
+
+          public func fetchTest3(limit: Int) async throws -> ResultResponse<Test> {
+            return try await self.requestFactory.resultResponse(
+              method: .get,
+              pathTemplate: "/test3",
+              pathParameters: nil,
+              queryParameters: [
+                "limit": limit
+              ],
+              body: Empty.none,
+              contentTypes: nil,
+              acceptTypes: self.defaultAcceptTypes,
+              headers: nil
+            )
+          }
+
+          public func fetchTest4OrNil(limit: Int) async throws -> ResultResponse<Test>? {
+            return try await nilifyResponse(
+                statuses: [404, 405],
+                problemTypes: []
+              ) {
+                try await fetchTest4(limit: limit)
+              }
+          }
+
+          public func fetchTest4(limit: Int) async throws -> ResultResponse<Test> {
+            return try await self.requestFactory.resultResponse(
+              method: .get,
+              pathTemplate: "/test4",
+              pathParameters: nil,
+              queryParameters: [
+                "limit": limit
+              ],
+              body: Empty.none,
+              contentTypes: nil,
+              acceptTypes: self.defaultAcceptTypes,
+              headers: nil
+            )
+          }
+
+          public func fetchTest5OrNil(limit: Int) async throws -> ResultResponse<Test>? {
+            return try await nilifyResponse(
+                statuses: [404],
+                problemTypes: []
+              ) {
+                try await fetchTest5(limit: limit)
+              }
+          }
+
+          public func fetchTest5(limit: Int) async throws -> ResultResponse<Test> {
+            return try await self.requestFactory.resultResponse(
+              method: .get,
+              pathTemplate: "/test5",
               pathParameters: nil,
               queryParameters: [
                 "limit": limit

--- a/generator/src/test/kotlin/io/outfoxx/sunday/generator/typescript/sunday/RequestMethodsTest.kt
+++ b/generator/src/test/kotlin/io/outfoxx/sunday/generator/typescript/sunday/RequestMethodsTest.kt
@@ -397,31 +397,299 @@ class RequestMethodsTest {
             requestFactory.registerProblem('http://example.com/another_not_found', AnotherNotFoundProblem);
           }
 
-          fetchTestOrNull(limit: number): Observable<Test | null> {
-            return this.fetchTest(limit)
+          fetchTest1OrNull(limit: number): Observable<Test | null> {
+            return this.fetchTest1(limit)
               .pipe(nullifyResponse(
                 [404, 405],
                 [TestNotFoundProblem, AnotherNotFoundProblem]
               ));
           }
 
-          fetchTest(limit: number): Observable<Test> {
+          fetchTest1(limit: number): Observable<Test> {
             return this.requestFactory.result(
                 {
                   method: 'GET',
-                  pathTemplate: '/tests',
+                  pathTemplate: '/test1',
                   queryParameters: {
                     limit
                   },
                   acceptTypes: this.defaultAcceptTypes
                 },
-                fetchTestReturnType
+                fetchTest1ReturnType
+            );
+          }
+
+          fetchTest2OrNull(limit: number): Observable<Test | null> {
+            return this.fetchTest2(limit)
+              .pipe(nullifyResponse(
+                [404],
+                [TestNotFoundProblem, AnotherNotFoundProblem]
+              ));
+          }
+
+          fetchTest2(limit: number): Observable<Test> {
+            return this.requestFactory.result(
+                {
+                  method: 'GET',
+                  pathTemplate: '/test2',
+                  queryParameters: {
+                    limit
+                  },
+                  acceptTypes: this.defaultAcceptTypes
+                },
+                fetchTest2ReturnType
+            );
+          }
+
+          fetchTest3OrNull(limit: number): Observable<Test | null> {
+            return this.fetchTest3(limit)
+              .pipe(nullifyResponse(
+                [],
+                [TestNotFoundProblem, AnotherNotFoundProblem]
+              ));
+          }
+
+          fetchTest3(limit: number): Observable<Test> {
+            return this.requestFactory.result(
+                {
+                  method: 'GET',
+                  pathTemplate: '/test3',
+                  queryParameters: {
+                    limit
+                  },
+                  acceptTypes: this.defaultAcceptTypes
+                },
+                fetchTest3ReturnType
+            );
+          }
+
+          fetchTest4OrNull(limit: number): Observable<Test | null> {
+            return this.fetchTest4(limit)
+              .pipe(nullifyResponse(
+                [404, 405],
+                []
+              ));
+          }
+
+          fetchTest4(limit: number): Observable<Test> {
+            return this.requestFactory.result(
+                {
+                  method: 'GET',
+                  pathTemplate: '/test4',
+                  queryParameters: {
+                    limit
+                  },
+                  acceptTypes: this.defaultAcceptTypes
+                },
+                fetchTest4ReturnType
+            );
+          }
+
+          fetchTest5OrNull(limit: number): Observable<Test | null> {
+            return this.fetchTest5(limit)
+              .pipe(nullifyResponse(
+                [404],
+                []
+              ));
+          }
+
+          fetchTest5(limit: number): Observable<Test> {
+            return this.requestFactory.result(
+                {
+                  method: 'GET',
+                  pathTemplate: '/test5',
+                  queryParameters: {
+                    limit
+                  },
+                  acceptTypes: this.defaultAcceptTypes
+                },
+                fetchTest5ReturnType
             );
           }
 
         }
 
-        const fetchTestReturnType: AnyType = [Test];
+        const fetchTest1ReturnType: AnyType = [Test];
+        const fetchTest2ReturnType: AnyType = [Test];
+        const fetchTest3ReturnType: AnyType = [Test];
+        const fetchTest4ReturnType: AnyType = [Test];
+        const fetchTest5ReturnType: AnyType = [Test];
+
+      """.trimIndent(),
+      buildString {
+        FileSpec.get(typeSpec)
+          .writeTo(this)
+      },
+    )
+  }
+
+  @Test
+  fun `test request method generation with nullify and result response`(
+    compiler: TypeScriptCompiler,
+    @ResourceUri("raml/resource-gen/req-methods-nullify.raml") testUri: URI,
+  ) {
+
+    val typeRegistry = TypeScriptTypeRegistry(setOf())
+
+    val builtTypes =
+      generate(testUri, typeRegistry, compiler) { document, shapeIndex ->
+        TypeScriptSundayGenerator(
+          document,
+          shapeIndex,
+          typeRegistry,
+          TypeScriptSundayGenerator.Options(
+            true,
+            "http://example.com/",
+            listOf("application/json"),
+            "API",
+          ),
+        )
+      }
+
+    val typeSpec = findTypeMod("API@!api", builtTypes)
+
+    assertEquals(
+      """
+        import {AnotherNotFoundProblem} from './another-not-found-problem';
+        import {Test} from './test';
+        import {TestNotFoundProblem} from './test-not-found-problem';
+        import {AnyType, MediaType, RequestFactory, ResultResponse, nullifyResponse} from '@outfoxx/sunday';
+        import {Observable} from 'rxjs';
+
+
+        export class API {
+
+          defaultContentTypes: Array<MediaType>;
+
+          defaultAcceptTypes: Array<MediaType>;
+
+          constructor(public requestFactory: RequestFactory,
+              options: { defaultContentTypes?: Array<MediaType>, defaultAcceptTypes?: Array<MediaType> } | undefined = undefined) {
+            this.defaultContentTypes =
+                options?.defaultContentTypes ?? [];
+            this.defaultAcceptTypes =
+                options?.defaultAcceptTypes ?? [MediaType.JSON];
+            requestFactory.registerProblem('http://example.com/test_not_found', TestNotFoundProblem);
+            requestFactory.registerProblem('http://example.com/another_not_found', AnotherNotFoundProblem);
+          }
+
+          fetchTest1OrNull(limit: number): Observable<ResultResponse<Test> | null> {
+            return this.fetchTest1(limit)
+              .pipe(nullifyResponse(
+                [404, 405],
+                [TestNotFoundProblem, AnotherNotFoundProblem]
+              ));
+          }
+
+          fetchTest1(limit: number): Observable<ResultResponse<Test>> {
+            return this.requestFactory.resultResponse(
+                {
+                  method: 'GET',
+                  pathTemplate: '/test1',
+                  queryParameters: {
+                    limit
+                  },
+                  acceptTypes: this.defaultAcceptTypes
+                },
+                fetchTest1ReturnType
+            );
+          }
+
+          fetchTest2OrNull(limit: number): Observable<ResultResponse<Test> | null> {
+            return this.fetchTest2(limit)
+              .pipe(nullifyResponse(
+                [404],
+                [TestNotFoundProblem, AnotherNotFoundProblem]
+              ));
+          }
+
+          fetchTest2(limit: number): Observable<ResultResponse<Test>> {
+            return this.requestFactory.resultResponse(
+                {
+                  method: 'GET',
+                  pathTemplate: '/test2',
+                  queryParameters: {
+                    limit
+                  },
+                  acceptTypes: this.defaultAcceptTypes
+                },
+                fetchTest2ReturnType
+            );
+          }
+
+          fetchTest3OrNull(limit: number): Observable<ResultResponse<Test> | null> {
+            return this.fetchTest3(limit)
+              .pipe(nullifyResponse(
+                [],
+                [TestNotFoundProblem, AnotherNotFoundProblem]
+              ));
+          }
+
+          fetchTest3(limit: number): Observable<ResultResponse<Test>> {
+            return this.requestFactory.resultResponse(
+                {
+                  method: 'GET',
+                  pathTemplate: '/test3',
+                  queryParameters: {
+                    limit
+                  },
+                  acceptTypes: this.defaultAcceptTypes
+                },
+                fetchTest3ReturnType
+            );
+          }
+
+          fetchTest4OrNull(limit: number): Observable<ResultResponse<Test> | null> {
+            return this.fetchTest4(limit)
+              .pipe(nullifyResponse(
+                [404, 405],
+                []
+              ));
+          }
+
+          fetchTest4(limit: number): Observable<ResultResponse<Test>> {
+            return this.requestFactory.resultResponse(
+                {
+                  method: 'GET',
+                  pathTemplate: '/test4',
+                  queryParameters: {
+                    limit
+                  },
+                  acceptTypes: this.defaultAcceptTypes
+                },
+                fetchTest4ReturnType
+            );
+          }
+
+          fetchTest5OrNull(limit: number): Observable<ResultResponse<Test> | null> {
+            return this.fetchTest5(limit)
+              .pipe(nullifyResponse(
+                [404],
+                []
+              ));
+          }
+
+          fetchTest5(limit: number): Observable<ResultResponse<Test>> {
+            return this.requestFactory.resultResponse(
+                {
+                  method: 'GET',
+                  pathTemplate: '/test5',
+                  queryParameters: {
+                    limit
+                  },
+                  acceptTypes: this.defaultAcceptTypes
+                },
+                fetchTest5ReturnType
+            );
+          }
+
+        }
+
+        const fetchTest1ReturnType: AnyType = [Test];
+        const fetchTest2ReturnType: AnyType = [Test];
+        const fetchTest3ReturnType: AnyType = [Test];
+        const fetchTest4ReturnType: AnyType = [Test];
+        const fetchTest5ReturnType: AnyType = [Test];
 
       """.trimIndent(),
       buildString {

--- a/generator/src/test/resources/raml/resource-gen/req-methods-nullify.raml
+++ b/generator/src/test/resources/raml/resource-gen/req-methods-nullify.raml
@@ -25,13 +25,55 @@ types:
       value: string
 
 
-/tests:
+/test1:
   get:
-    displayName: fetchTest
+    displayName: fetchTest1
     queryParameters:
       limit: integer
     (sunday.problems): [test_not_found, another_not_found]
     (sunday.nullify): [test_not_found, another_not_found, 404, 405]
+    responses:
+      200:
+        body: Test
+
+/test2:
+  get:
+    displayName: fetchTest2
+    queryParameters:
+      limit: integer
+    (sunday.problems): [test_not_found, another_not_found]
+    (sunday.nullify): [test_not_found, another_not_found, 404]
+    responses:
+      200:
+        body: Test
+
+/test3:
+  get:
+    displayName: fetchTest3
+    queryParameters:
+      limit: integer
+    (sunday.problems): [test_not_found, another_not_found]
+    (sunday.nullify): [test_not_found, another_not_found]
+    responses:
+      200:
+        body: Test
+
+/test4:
+  get:
+    displayName: fetchTest4
+    queryParameters:
+      limit: integer
+    (sunday.nullify): [404, 405]
+    responses:
+      200:
+        body: Test
+
+/test5:
+  get:
+    displayName: fetchTest5
+    queryParameters:
+      limit: integer
+    (sunday.nullify): [404]
     responses:
       200:
         body: Test


### PR DESCRIPTION
This PR also uses multiple catch clauses (in Kotlin and Swift) when possible to implement nullify methods.