### PR TITLE
Add `targetSourceSet` to `SundayGeneration`

### DIFF
--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -35,9 +35,12 @@ application {
   mainClass.set("io.outfoxx.sunday.generator.MainKt")
 }
 
-tasks.shadowJar.configure {
-  archiveClassifier.set("")
-  minimize()
+tasks {
+  shadowJar.configure {
+    dependsOn(assembleDist)
+    archiveClassifier.set("")
+    minimize()
+  }
 }
 
 publishing {

--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -27,13 +27,16 @@ dependencies {
   testImplementation("com.github.tschuchortdev:kotlin-compile-testing:$kotlinCompileTestingVersion")
 }
 
-tasks.shadowJar.configure {
-  isZip64 = true
-  archiveClassifier.set("")
-  dependencies {
-    exclude(dependency("org.jetbrains.kotlin:.*"))
+tasks {
+  shadowJar.configure {
+    dependsOn(jar)
+    isZip64 = true
+    archiveClassifier.set("")
+    dependencies {
+      exclude(dependency("org.jetbrains.kotlin:.*"))
+    }
+    minimize()
   }
-  minimize()
 }
 
 gradlePlugin {

--- a/gradle-plugin/src/main/kotlin/io/outfoxx/sunday/generator/gradle/SundayGeneration.kt
+++ b/gradle-plugin/src/main/kotlin/io/outfoxx/sunday/generator/gradle/SundayGeneration.kt
@@ -26,6 +26,7 @@ import org.gradle.api.file.FileCollection
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
+import org.gradle.api.tasks.SourceSet.MAIN_SOURCE_SET_NAME
 
 class SundayGeneration(
   val name: String,
@@ -58,4 +59,5 @@ class SundayGeneration(
   val alwaysUseResponseReturn: Property<Boolean> = objects.property(Boolean::class.java)
   val useResultResponseReturn: Property<Boolean> = objects.property(Boolean::class.java)
   val outputDir: Property<Directory> = objects.directoryProperty().convention(outputDirDef)
+  val targetSourceSet: Property<String> = objects.property(String::class.java).convention(MAIN_SOURCE_SET_NAME)
 }


### PR DESCRIPTION
This allows generting code other source-sets (e.g. `test` or `integrationTest`).
