### PR TITLE
ts: Use strings for enum discriminator initializers

### DIFF
--- a/generator/src/test/kotlin/io/outfoxx/sunday/generator/typescript/RamlDiscriminatedTypesTest.kt
+++ b/generator/src/test/kotlin/io/outfoxx/sunday/generator/typescript/RamlDiscriminatedTypesTest.kt
@@ -203,7 +203,6 @@ class RamlDiscriminatedTypesTest {
     assertEquals(
       """
         import {Child1, Child2} from './index';
-        import {Type} from './type';
         import {JsonSubTypes, JsonTypeInfo, JsonTypeInfoAs, JsonTypeInfoId} from '@outfoxx/jackson-js';
         
         
@@ -217,8 +216,8 @@ class RamlDiscriminatedTypesTest {
         })
         @JsonSubTypes({
           types: [
-            {class: () => Child1, name: Type.Child1},
-            {class: () => Child2, name: Type.Child2}
+            {class: () => Child1, name: 'Child1' /* Type.Child1 */},
+            {class: () => Child2, name: 'Child2' /* Type.Child2 */}
           ]
         })
         export abstract class Parent implements ParentSpec {

--- a/generator/src/test/resources/raml/type-gen/annotations/type-external-discriminator-enum.raml
+++ b/generator/src/test/resources/raml/type-gen/annotations/type-external-discriminator-enum.raml
@@ -1,0 +1,50 @@
+#%RAML 1.0
+title: Test API
+uses:
+  sunday: https://outfoxx.github.io/sunday-generator/sunday.raml
+mediaType:
+- application/json
+
+types:
+
+  Type:
+    type: string
+    enum:
+    - child-1
+    - child-2
+
+  Parent:
+    type: object
+    discriminator: type
+    (sunday.externallyDiscriminated): true
+    properties:
+      type: Type
+
+  Child1:
+    type: Parent
+    discriminatorValue: child-1
+    properties:
+      value?: string
+
+  Child2:
+    type: Parent
+    discriminatorValue: child-2
+    properties:
+      value?: string
+
+  Test:
+    type: object
+    properties:
+      parent:
+        type: Parent
+        (sunday.externalDiscriminator): parentType
+      parentType: Type
+
+/tests/{id}:
+
+  get:
+    displayName: fetchTest
+    responses:
+      200:
+        body:
+          type: Test


### PR DESCRIPTION
This is a temporary workaround for a problem related to nested enums and their initialization order.