### PR TITLE
Fix issues with Swift type generation

### DIFF
--- a/generator/src/main/kotlin/io/outfoxx/sunday/generator/swift/SwiftTypeRegistry.kt
+++ b/generator/src/main/kotlin/io/outfoxx/sunday/generator/swift/SwiftTypeRegistry.kt
@@ -848,19 +848,21 @@ class SwiftTypeRegistry(
     }
 
     if (isRoot || localDeclaredProperties.isNotEmpty() || discriminatorProperty != null) {
+
       val codingKeysBuilder =
         TypeSpec.enumBuilder(codingKeysTypeName)
           .addModifiers(FILEPRIVATE)
-          .apply {
-            if (localDeclaredProperties.isNotEmpty() || discriminatorProperty != null) {
-              addSuperType(STRING)
-            }
-          }
-          .addSuperType(CODING_KEY)
 
       if (isRoot && discriminatorProperty != null) {
+        codingKeysBuilder.addSuperType(STRING)
         codingKeysBuilder.addEnumCase(discriminatorProperty.swiftIdentifierName, discriminatorProperty.name!!)
       }
+
+      if (localDeclaredProperties.any { it.name != discriminatorPropertyName }) {
+        codingKeysBuilder.addSuperType(STRING)
+      }
+
+      codingKeysBuilder.addSuperType(CODING_KEY)
 
       localDeclaredProperties
         .filter { it.name != discriminatorProperty?.name }

--- a/generator/src/test/kotlin/io/outfoxx/sunday/generator/kotlin/jaxrs/RequestCoroutineMethodsTest.kt
+++ b/generator/src/test/kotlin/io/outfoxx/sunday/generator/kotlin/jaxrs/RequestCoroutineMethodsTest.kt
@@ -79,6 +79,10 @@ class RequestCoroutineMethodsTest {
           @GET
           @Path(value = "/tests")
           public suspend fun fetchTest(): Response
+
+          @GET
+          @Path(value = "/tests/derived")
+          public suspend fun fetchDerivedTest(): Response
         }
 
       """.trimIndent(),
@@ -122,6 +126,7 @@ class RequestCoroutineMethodsTest {
       """
         package io.test.service
 
+        import io.test.Base
         import io.test.Test
         import javax.ws.rs.Consumes
         import javax.ws.rs.GET
@@ -134,6 +139,10 @@ class RequestCoroutineMethodsTest {
           @GET
           @Path(value = "/tests")
           public suspend fun fetchTest(): Test
+
+          @GET
+          @Path(value = "/tests/derived")
+          public suspend fun fetchDerivedTest(): Base
         }
 
       """.trimIndent(),

--- a/generator/src/test/kotlin/io/outfoxx/sunday/generator/kotlin/jaxrs/RequestReactiveMethodsTest.kt
+++ b/generator/src/test/kotlin/io/outfoxx/sunday/generator/kotlin/jaxrs/RequestReactiveMethodsTest.kt
@@ -86,6 +86,10 @@ class RequestReactiveMethodsTest {
           @GET
           @Path(value = "/tests")
           public fun fetchTest(): CompletionStage<Response>
+
+          @GET
+          @Path(value = "/tests/derived")
+          public fun fetchDerivedTest(): CompletionStage<Response>
         }
 
       """.trimIndent(),
@@ -129,6 +133,7 @@ class RequestReactiveMethodsTest {
       """
         package io.test.service
 
+        import io.test.Base
         import io.test.Test
         import java.util.concurrent.CompletionStage
         import javax.ws.rs.Consumes
@@ -142,6 +147,10 @@ class RequestReactiveMethodsTest {
           @GET
           @Path(value = "/tests")
           public fun fetchTest(): CompletionStage<Test>
+
+          @GET
+          @Path(value = "/tests/derived")
+          public fun fetchDerivedTest(): CompletionStage<Base>
         }
 
       """.trimIndent(),

--- a/generator/src/test/kotlin/io/outfoxx/sunday/generator/kotlin/jaxrs/ResponseBodyContentTest.kt
+++ b/generator/src/test/kotlin/io/outfoxx/sunday/generator/kotlin/jaxrs/ResponseBodyContentTest.kt
@@ -69,6 +69,10 @@ class ResponseBodyContentTest {
           @GET
           @Path(value = "/tests")
           public fun fetchTest(): Response
+
+          @GET
+          @Path(value = "/tests/derived")
+          public fun fetchDerivedTest(): Response
         }
 
       """.trimIndent(),
@@ -148,6 +152,7 @@ class ResponseBodyContentTest {
       """
         package io.test.service
 
+        import io.test.Base
         import io.test.Test
         import javax.ws.rs.Consumes
         import javax.ws.rs.GET
@@ -160,6 +165,10 @@ class ResponseBodyContentTest {
           @GET
           @Path(value = "/tests")
           public fun fetchTest(): Test
+
+          @GET
+          @Path(value = "/tests/derived")
+          public fun fetchDerivedTest(): Base
         }
 
       """.trimIndent(),

--- a/generator/src/test/kotlin/io/outfoxx/sunday/generator/kotlin/sunday/ResponseBodyContentTest.kt
+++ b/generator/src/test/kotlin/io/outfoxx/sunday/generator/kotlin/sunday/ResponseBodyContentTest.kt
@@ -60,6 +60,7 @@ class ResponseBodyContentTest {
         import io.outfoxx.sunday.MediaType
         import io.outfoxx.sunday.RequestFactory
         import io.outfoxx.sunday.http.Method
+        import io.test.Base
         import io.test.Test
         import kotlin.collections.List
 
@@ -72,6 +73,13 @@ class ResponseBodyContentTest {
             .result(
               method = Method.Get,
               pathTemplate = "/tests",
+              acceptTypes = this.defaultAcceptTypes
+            )
+
+          public suspend fun fetchDerivedTest(): Base = this.requestFactory
+            .result(
+              method = Method.Get,
+              pathTemplate = "/tests/derived",
               acceptTypes = this.defaultAcceptTypes
             )
         }

--- a/generator/src/test/kotlin/io/outfoxx/sunday/generator/swift/sunday/ResponseBodyContentTest.kt
+++ b/generator/src/test/kotlin/io/outfoxx/sunday/generator/swift/sunday/ResponseBodyContentTest.kt
@@ -88,6 +88,19 @@ class ResponseBodyContentTest {
             )
           }
 
+          public func fetchDerivedTest() async throws -> Base {
+            return try await (self.requestFactory.result(
+              method: .get,
+              pathTemplate: "/tests/derived",
+              pathParameters: nil,
+              queryParameters: nil,
+              body: Empty.none,
+              contentTypes: nil,
+              acceptTypes: self.defaultAcceptTypes,
+              headers: nil
+            ) as Base.AnyRef).value
+          }
+
         }
 
       """.trimIndent(),

--- a/generator/src/test/kotlin/io/outfoxx/sunday/generator/typescript/sunday/ResponseBodyContentTest.kt
+++ b/generator/src/test/kotlin/io/outfoxx/sunday/generator/typescript/sunday/ResponseBodyContentTest.kt
@@ -57,6 +57,7 @@ class ResponseBodyContentTest {
 
     assertEquals(
       """
+        import {Base} from './base';
         import {Test} from './test';
         import {AnyType, MediaType, RequestFactory} from '@outfoxx/sunday';
         import {Observable} from 'rxjs';
@@ -87,9 +88,21 @@ class ResponseBodyContentTest {
             );
           }
 
+          fetchDerivedTest(): Observable<Base> {
+            return this.requestFactory.result(
+                {
+                  method: 'GET',
+                  pathTemplate: '/tests/derived',
+                  acceptTypes: this.defaultAcceptTypes
+                },
+                fetchDerivedTestReturnType
+            );
+          }
+
         }
 
         const fetchTestReturnType: AnyType = [Test];
+        const fetchDerivedTestReturnType: AnyType = [Base];
 
       """.trimIndent(),
       buildString {

--- a/generator/src/test/resources/raml/resource-gen/res-body-param.raml
+++ b/generator/src/test/resources/raml/resource-gen/res-body-param.raml
@@ -10,6 +10,17 @@ types:
     properties:
       value: string
 
+  Base:
+    type: object
+    discriminator: type
+    properties:
+      type: string
+
+  Derived:
+    type: Base
+    discriminatorValue: derived
+    properties:
+      value: string
 
 /tests:
   get:
@@ -17,3 +28,10 @@ types:
     responses:
       200:
         body: Test
+
+/tests/derived:
+  get:
+    displayName: fetchDerivedTest
+    responses:
+      200:
+        body: Base


### PR DESCRIPTION
* Correctly generate empty `CodingKeys`
* Generate `AnyRef` for polymorphic endpoint body types