### PR TITLE
Support Jakarta EE & Java EE packages

### DIFF
--- a/generator/build.gradle.kts
+++ b/generator/build.gradle.kts
@@ -10,16 +10,8 @@ val amfClientVersion: String by project
 val kotlinPoetVersion: String by project
 val typeScriptPoetVersion: String by project
 val swiftPoetVersion: String by project
-val jacksonVersion: String by project
 
-val sundayKtVersion: String by project
 val kotlinCoroutinesVersion: String by project
-val jaxrsVersion: String by project
-val validationVersion: String by project
-val zalandoProblemVersion: String by project
-val mutinyVersion: String by project
-val rxJava3Version: String by project
-val rxJava2Version: String by project
 
 val junitVersion: String by project
 val hamcrestVersion: String by project
@@ -28,6 +20,21 @@ val dockerJavaVersion: String by project
 
 val jcolorVersion: String by project
 val jimfsVersion: String by project
+
+// Test runtime deps
+val jakartaJaxrsVersion: String by project
+val javaxJaxrsVersion: String by project
+
+val sundayKtVersion: String by project
+
+val jacksonVersion: String by project
+
+val validationVersion: String by project
+val zalandoProblemVersion: String by project
+val mutinyVersion: String by project
+val rxJava3Version: String by project
+val rxJava2Version: String by project
+
 
 configurations.compileClasspath {
   resolutionStrategy {
@@ -39,27 +46,25 @@ dependencies {
 
   api("com.github.amlorg:amf-api-contract_2.12:$amfClientVersion")
 
-  api("com.fasterxml.jackson.core:jackson-databind:$jacksonVersion")
-
   api("com.squareup:kotlinpoet:$kotlinPoetVersion")
   api("io.outfoxx:typescriptpoet:$typeScriptPoetVersion")
   api("io.outfoxx:swiftpoet:$swiftPoetVersion")
-
-  implementation("io.outfoxx.sunday:sunday-core:$sundayKtVersion") { exclude(group = "*") }
-  implementation("org.jboss.spec.javax.ws.rs:jboss-jaxrs-api_2.1_spec:$jaxrsVersion") { exclude(group = "*") }
-  implementation("javax.validation:validation-api:$validationVersion") { exclude(group = "*") }
-  implementation("org.zalando:problem:$zalandoProblemVersion") { exclude(group = "*") }
 
   //
   // TESTING
   //
 
-  // redclare these w/o exclude for testing to work
+  // START: generated code dependencies
+  testImplementation("com.fasterxml.jackson.core:jackson-databind:$jacksonVersion")
   testImplementation("io.outfoxx.sunday:sunday-core:$sundayKtVersion")
-
+  testImplementation("org.jboss.spec.javax.ws.rs:jboss-jaxrs-api_2.1_spec:$javaxJaxrsVersion")
+  testImplementation("jakarta.ws.rs:jakarta.ws.rs-api:$jakartaJaxrsVersion")
+  testImplementation("javax.validation:validation-api:$validationVersion")
+  testImplementation("org.zalando:problem:$zalandoProblemVersion")
   testImplementation("io.smallrye.reactive:mutiny:$mutinyVersion")
   testImplementation("io.reactivex.rxjava3:rxjava:$rxJava3Version")
   testImplementation("io.reactivex.rxjava2:rxjava:$rxJava2Version")
+  // END: generated code dependencies
 
   testImplementation("org.slf4j:slf4j-jdk14:$slf4jVersion")
 

--- a/generator/src/main/kotlin/io/outfoxx/sunday/generator/common/HttpStatus.kt
+++ b/generator/src/main/kotlin/io/outfoxx/sunday/generator/common/HttpStatus.kt
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2020 Outfox, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.outfoxx.sunday.generator.common
+
+@Suppress("MagicNumber")
+enum class HttpStatus(val code: Int, val text: String) {
+  // Informational 1xx
+  CONTINUE(100, "Continue"),
+  SWITCHING_PROTOCOLS(101, "Switching Protocols"),
+  PROCESSING(102, "Processing"),
+  CHECKPOINT(103, "Checkpoint"),
+
+  // Success 2xx
+  OK(200, "OK"),
+  CREATED(201, "Created"),
+  ACCEPTED(202, "Accepted"),
+  NON_AUTHORITATIVE_INFORMATION(203, "Non-Authoritative Information"),
+  NO_CONTENT(204, "No Content"),
+  RESET_CONTENT(205, "Reset Content"),
+  PARTIAL_CONTENT(206, "Partial Content"),
+  MULTI_STATUS(207, "Multi-Status"),
+  ALREADY_REPORTED(208, "Already Reported"),
+  IM_USED(226, "IM Used"),
+
+  // Redirection 3xx
+  MULTIPLE_CHOICES(300, "Multiple Choices"),
+  MOVED_PERMANENTLY(301, "Moved Permanently"),
+  FOUND(302, "Found"),
+  SEE_OTHER(303, "See Other"),
+  NOT_MODIFIED(304, "Not Modified"),
+  USE_PROXY(305, "Use Proxy"),
+  TEMPORARY_REDIRECT(307, "Temporary Redirect"),
+  PERMANENT_REDIRECT(308, "Permanent Redirect"),
+
+  // Client Error 4xx
+  BAD_REQUEST(400, "Bad Request"),
+  UNAUTHORIZED(401, "Unauthorized"),
+  PAYMENT_REQUIRED(402, "Payment Required"),
+  FORBIDDEN(403, "Forbidden"),
+  NOT_FOUND(404, "Not Found"),
+  METHOD_NOT_ALLOWED(405, "Method Not Allowed"),
+  NOT_ACCEPTABLE(406, "Not Acceptable"),
+  PROXY_AUTHENTICATION_REQUIRED(407, "Proxy Authentication Required"),
+  REQUEST_TIMEOUT(408, "Request Timeout"),
+  CONFLICT(409, "Conflict"),
+  GONE(410, "Gone"),
+  LENGTH_REQUIRED(411, "Length Required"),
+  PRECONDITION_FAILED(412, "Precondition Failed"),
+  REQUEST_ENTITY_TOO_LARGE(413, "Request Entity Too Large"),
+  REQUEST_URI_TOO_LONG(414, "URI Too Long"),
+  UNSUPPORTED_MEDIA_TYPE(415, "Unsupported Media Type"),
+  REQUESTED_RANGE_NOT_SATISFIABLE(416, "Range Not Satisfiable"),
+  EXPECTATION_FAILED(417, "Expectation Failed"),
+  I_AM_A_TEAPOT(418, "I'm a Teapot"),
+  MISDIRECTED_REQUEST(421, "Misdirected Request"),
+  UNPROCESSABLE_ENTITY(422, "Unprocessable Entity"),
+  LOCKED(423, "Locked"),
+  FAILED_DEPENDENCY(424, "Failed Dependency"),
+  TOO_EARLY(425, "Too Early"),
+  UPGRADE_REQUIRED(426, "Upgrade Required"),
+  PRECONDITION_REQUIRED(428, "Precondition Required"),
+  TOO_MANY_REQUESTS(429, "Too Many Requests"),
+  REQUEST_HEADER_FIELDS_TOO_LARGE(431, "Request Header Fields Too Large"),
+  UNAVAILABLE_FOR_LEGAL_REASONS(451, "Unavailable For Legal Reasons"),
+
+  // Server Error 5xx
+  INTERNAL_SERVER_ERROR(500, "Internal Server Error"),
+  NOT_IMPLEMENTED(501, "Not Implemented"),
+  BAD_GATEWAY(502, "Bad Gateway"),
+  SERVICE_UNAVAILABLE(503, "Service Unavailable"),
+  GATEWAY_TIMEOUT(504, "Gateway Timeout"),
+  HTTP_VERSION_NOT_SUPPORTED(505, "HTTP Version Not Supported"),
+  VARIANT_ALSO_NEGOTIATES(506, "Variant Also Negotiates"),
+  INSUFFICIENT_STORAGE(507, "Insufficient Storage"),
+  LOOP_DETECTED(508, "Loop Detected"),
+  BANDWIDTH_LIMIT_EXCEEDED(509, "Bandwidth Limit Exceeded"),
+  NOT_EXTENDED(510, "Not Extended"),
+  NETWORK_AUTHENTICATION_REQUIRED(511, "Network Authentication Required");
+
+  companion object {
+    private val map = values().associateBy(HttpStatus::code)
+
+    fun valueOf(code: Int): HttpStatus {
+      return map[code] ?: throw IllegalArgumentException("No HTTP status found for code $code")
+    }
+
+    fun find(code: Int): HttpStatus? {
+      return map[code]
+    }
+  }
+}

--- a/generator/src/main/kotlin/io/outfoxx/sunday/generator/kotlin/utils/BeanValidationTypes.kt
+++ b/generator/src/main/kotlin/io/outfoxx/sunday/generator/kotlin/utils/BeanValidationTypes.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2020 Outfox, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.outfoxx.sunday.generator.kotlin.utils
+
+import com.squareup.kotlinpoet.ClassName
+
+class BeanValidationTypes(basePackage: String) {
+
+  val valid = ClassName.bestGuess("$basePackage.validation.Valid")
+  val decimalMax = ClassName.bestGuess("$basePackage.validation.constraints.DecimalMax")
+  val decimalMin = ClassName.bestGuess("$basePackage.validation.constraints.DecimalMin")
+  val max = ClassName.bestGuess("$basePackage.validation.constraints.Max")
+  val min = ClassName.bestGuess("$basePackage.validation.constraints.Min")
+  val pattern = ClassName.bestGuess("$basePackage.validation.constraints.Pattern")
+  val size = ClassName.bestGuess("$basePackage.validation.constraints.Size")
+
+  companion object {
+
+    val JAVAX = BeanValidationTypes("javax")
+    val JAKARTA = BeanValidationTypes("jakarta")
+  }
+}

--- a/generator/src/main/kotlin/io/outfoxx/sunday/generator/kotlin/utils/JacksonTypes.kt
+++ b/generator/src/main/kotlin/io/outfoxx/sunday/generator/kotlin/utils/JacksonTypes.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2020 Outfox, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.outfoxx.sunday.generator.kotlin.utils
+
+import com.squareup.kotlinpoet.ClassName
+
+val JACKSON_JSON_CREATOR = ClassName.bestGuess("com.fasterxml.jackson.annotation.JsonCreator")
+val JACKSON_JSON_IGNORE = ClassName.bestGuess("com.fasterxml.jackson.annotation.JsonIgnore")
+val JACKSON_JSON_INCLUDE = ClassName.bestGuess("com.fasterxml.jackson.annotation.JsonInclude")
+val JACKSON_JSON_INCLUDE_INCLUDE = ClassName.bestGuess("com.fasterxml.jackson.annotation.JsonInclude.Include")
+const val JACKSON_JSON_INCLUDE_NON_EMPTY = "NON_EMPTY"
+val JACKSON_JSON_PROPERTY = ClassName.bestGuess("com.fasterxml.jackson.annotation.JsonProperty")
+val JACKSON_JSON_SUBTYPES = ClassName.bestGuess("com.fasterxml.jackson.annotation.JsonSubTypes")
+val JACKSON_JSON_SUBTYPES_TYPE = ClassName.bestGuess("com.fasterxml.jackson.annotation.JsonSubTypes.Type")
+val JACKSON_JSON_TYPEINFO = ClassName.bestGuess("com.fasterxml.jackson.annotation.JsonTypeInfo")
+val JACKSON_JSON_TYPEINFO_ID = ClassName.bestGuess("com.fasterxml.jackson.annotation.JsonTypeInfo.Id")
+const val JACKSON_JSON_TYPEINFO_ID_NAME = "NAME"
+val JACKSON_JSON_TYPEINFO_AS = ClassName.bestGuess("com.fasterxml.jackson.annotation.JsonTypeInfo.As")
+const val JACKSON_JSON_TYPEINFO_AS_EXTERNAL_PROPERTY = "EXTERNAL_PROPERTY"
+const val JACKSON_JSON_TYPEINFO_AS_EXISTING_PROPERTY = "EXISTING_PROPERTY"
+val JACKSON_JSON_TYPENAME = ClassName.bestGuess("com.fasterxml.jackson.annotation.JsonTypeName")
+
+val JSON_NODE = ClassName.bestGuess("com.fasterxml.jackson.databind.JsonNode")
+val OBJECT_MAPPER = ClassName.bestGuess("com.fasterxml.jackson.databind.ObjectMapper")

--- a/generator/src/main/kotlin/io/outfoxx/sunday/generator/kotlin/utils/JaxRsTypes.kt
+++ b/generator/src/main/kotlin/io/outfoxx/sunday/generator/kotlin/utils/JaxRsTypes.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2020 Outfox, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.outfoxx.sunday.generator.kotlin.utils
+
+import com.squareup.kotlinpoet.ClassName
+import io.outfoxx.sunday.generator.genError
+
+class JaxRsTypes(basePackage: String) {
+
+  val consumes = ClassName.bestGuess("$basePackage.ws.rs.Consumes")
+  val delete = ClassName.bestGuess("$basePackage.ws.rs.DELETE")
+  val defaultvalue = ClassName.bestGuess("$basePackage.ws.rs.DefaultValue")
+  val get = ClassName.bestGuess("$basePackage.ws.rs.GET")
+  val head = ClassName.bestGuess("$basePackage.ws.rs.HEAD")
+  val headerParam = ClassName.bestGuess("$basePackage.ws.rs.HeaderParam")
+  val options = ClassName.bestGuess("$basePackage.ws.rs.OPTIONS")
+  val patch = ClassName.bestGuess("$basePackage.ws.rs.PATCH")
+  val post = ClassName.bestGuess("$basePackage.ws.rs.POST")
+  val put = ClassName.bestGuess("$basePackage.ws.rs.PUT")
+  val path = ClassName.bestGuess("$basePackage.ws.rs.Path")
+  val pathParam = ClassName.bestGuess("$basePackage.ws.rs.PathParam")
+  val produces = ClassName.bestGuess("$basePackage.ws.rs.Produces")
+  val queryParam = ClassName.bestGuess("$basePackage.ws.rs.QueryParam")
+  val response = ClassName.bestGuess("$basePackage.ws.rs.core.Response")
+  val asyncResponse = ClassName.bestGuess("$basePackage.ws.rs.container.AsyncResponse")
+  val suspended = ClassName.bestGuess("$basePackage.ws.rs.container.Suspended")
+  val context = ClassName.bestGuess("$basePackage.ws.rs.core.Context")
+  val uriInfo = ClassName.bestGuess("$basePackage.ws.rs.core.UriInfo")
+  val sse = ClassName.bestGuess("$basePackage.ws.rs.sse.Sse")
+  val sseEventSink = ClassName.bestGuess("$basePackage.ws.rs.sse.SseEventSink")
+  val sseEventSource = ClassName.bestGuess("$basePackage.ws.rs.sse.SseEventSource")
+
+  fun httpMethod(methodName: String) =
+    when (methodName.uppercase()) {
+      "DELETE" -> delete
+      "GET" -> get
+      "HEAD" -> head
+      "OPTIONS" -> options
+      "POST" -> post
+      "PUT" -> put
+      "PATCH" -> patch
+      else -> genError("Unsupported HTTP method: $methodName")
+    }
+
+  companion object {
+
+    val JAVAX = JaxRsTypes("javax")
+    val JAKARTA = JaxRsTypes("jakarta")
+  }
+}

--- a/generator/src/main/kotlin/io/outfoxx/sunday/generator/kotlin/utils/SundayTypes.kt
+++ b/generator/src/main/kotlin/io/outfoxx/sunday/generator/kotlin/utils/SundayTypes.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2020 Outfox, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.outfoxx.sunday.generator.kotlin.utils
+
+import com.squareup.kotlinpoet.ClassName
+
+val RESULT_RESPONSE = ClassName.bestGuess("io.outfoxx.sunday.http.ResultResponse")
+val SUNDAY_EVENT_SOURCE = ClassName.bestGuess("io.outfoxx.sunday.EventSource")
+val SUNDAY_METHOD = ClassName.bestGuess("io.outfoxx.sunday.http.Method")
+val SUNDAY_REQUEST = ClassName.bestGuess("io.outfoxx.sunday.http.Request")
+val SUNDAY_RESPONSE = ClassName.bestGuess("io.outfoxx.sunday.http.Response")
+val SUNDAY_RESULT_RESPONSE = ClassName.bestGuess("io.outfoxx.sunday.http.ResultResponse")
+
+val THROWABLE_PROBLEM = ClassName.bestGuess("org.zalando.problem.ThrowableProblem")
+
+val MEDIA_TYPE = ClassName.bestGuess("io.outfoxx.sunday.MediaType")
+val REQUEST_FACTORY = ClassName.bestGuess("io.outfoxx.sunday.RequestFactory")
+val URI_TEMPLATE = ClassName.bestGuess("io.outfoxx.sunday.URITemplate")
+
+val PATCH_OP = ClassName("io.outfoxx.sunday.json.patch", "PatchOp")
+val PATCH_SET_OP = PATCH_OP.nestedClass("Set")
+val UPDATE_OP = ClassName("io.outfoxx.sunday.json.patch", "UpdateOp")
+
+val PATCH = ClassName("io.outfoxx.sunday.json.patch", "Patch")

--- a/generator/src/main/kotlin/io/outfoxx/sunday/generator/kotlin/utils/ZalandoTypes.kt
+++ b/generator/src/main/kotlin/io/outfoxx/sunday/generator/kotlin/utils/ZalandoTypes.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2020 Outfox, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.outfoxx.sunday.generator.kotlin.utils
+
+import com.squareup.kotlinpoet.ClassName
+
+val ZALANDO_ABSTRACT_THROWABLE_PROBLEM = ClassName.bestGuess("org.zalando.problem.AbstractThrowableProblem")
+val ZALANDO_EXCEPTIONAL = ClassName.bestGuess("org.zalando.problem.Exceptional")
+val ZALANDO_STATUS = ClassName.bestGuess("org.zalando.problem.Status")
+val ZALANDO_THROWABLE_PROBLEM = ClassName.bestGuess("org.zalando.problem.ThrowableProblem")

--- a/generator/src/main/kotlin/io/outfoxx/sunday/generator/swift/SwiftGenerator.kt
+++ b/generator/src/main/kotlin/io/outfoxx/sunday/generator/swift/SwiftGenerator.kt
@@ -41,6 +41,7 @@ import io.outfoxx.sunday.generator.APIAnnotationName.SwiftModelModule
 import io.outfoxx.sunday.generator.APIAnnotationName.SwiftModule
 import io.outfoxx.sunday.generator.Generator
 import io.outfoxx.sunday.generator.ProblemTypeDefinition
+import io.outfoxx.sunday.generator.common.HttpStatus.NO_CONTENT
 import io.outfoxx.sunday.generator.common.NameGenerator
 import io.outfoxx.sunday.generator.common.ShapeIndex
 import io.outfoxx.sunday.generator.genError
@@ -89,7 +90,6 @@ import io.outfoxx.swiftpoet.TypeSpec
 import io.outfoxx.swiftpoet.VOID
 import java.net.URI
 import java.net.URISyntaxException
-import javax.ws.rs.core.Response.Status.NO_CONTENT
 
 /**
  * Generator for Swift language framework targets
@@ -277,7 +277,7 @@ abstract class SwiftGenerator(
         operation.successes.forEach { response ->
 
           val responseBodyType = response.payloads.firstOrNull()?.schema
-          if (response.statusCode != NO_CONTENT.statusCode.toString() && responseBodyType != null) {
+          if (response.statusCode != "${NO_CONTENT.code}" && responseBodyType != null) {
 
             val responseBodyTypeNameContext =
               SwiftResolutionContext(

--- a/generator/src/main/kotlin/io/outfoxx/sunday/generator/typescript/TypeScriptGenerator.kt
+++ b/generator/src/main/kotlin/io/outfoxx/sunday/generator/typescript/TypeScriptGenerator.kt
@@ -40,6 +40,7 @@ import io.outfoxx.sunday.generator.APIAnnotationName.ServiceName
 import io.outfoxx.sunday.generator.APIAnnotationName.TypeScriptModule
 import io.outfoxx.sunday.generator.Generator
 import io.outfoxx.sunday.generator.ProblemTypeDefinition
+import io.outfoxx.sunday.generator.common.HttpStatus.NO_CONTENT
 import io.outfoxx.sunday.generator.common.NameGenerator
 import io.outfoxx.sunday.generator.common.ShapeIndex
 import io.outfoxx.sunday.generator.genError
@@ -90,7 +91,6 @@ import io.outfoxx.typescriptpoet.TypeName.Companion.VOID
 import io.outfoxx.typescriptpoet.tag
 import java.net.URI
 import java.net.URISyntaxException
-import javax.ws.rs.core.Response.Status.NO_CONTENT
 
 /**
  * Generator for TypeScript language framework targets
@@ -308,7 +308,7 @@ abstract class TypeScriptGenerator(
         operation.successes.forEach { response ->
 
           val responseBodyType = response.payloads.firstOrNull()?.schema
-          if (response.statusCode != NO_CONTENT.statusCode.toString() && responseBodyType != null) {
+          if (response.statusCode != "${NO_CONTENT.code}" && responseBodyType != null) {
 
             val responseBodyTypeName =
               resolveTypeName(responseBodyType, typeName.nested("${operation.typeScriptTypeName}ResponseBody"))

--- a/generator/src/test/kotlin/io/outfoxx/sunday/generator/kotlin/RamlDeclaredTypesTest.kt
+++ b/generator/src/test/kotlin/io/outfoxx/sunday/generator/kotlin/RamlDeclaredTypesTest.kt
@@ -73,7 +73,7 @@ class RamlDeclaredTypesTest {
         public interface Test : Test {
           public val value2: String
         }
-        
+
       """.trimIndent(),
       buildString {
         FileSpec.get("io.test", typeSpec)

--- a/generator/src/test/kotlin/io/outfoxx/sunday/generator/kotlin/RamlEnumTypesTest.kt
+++ b/generator/src/test/kotlin/io/outfoxx/sunday/generator/kotlin/RamlEnumTypesTest.kt
@@ -45,7 +45,7 @@ class RamlEnumTypesTest {
     assertEquals(
       """
         package io.test
-        
+
         public enum class TestEnum {
           None,
           Some,
@@ -54,7 +54,7 @@ class RamlEnumTypesTest {
           KebabCase,
           InvalidChar,
         }
-        
+
       """.trimIndent(),
       buildString {
         FileSpec.get("io.test", typeSpec)
@@ -77,7 +77,7 @@ class RamlEnumTypesTest {
         package io.test
 
         import com.fasterxml.jackson.`annotation`.JsonProperty
-        
+
         public enum class TestEnum {
           @JsonProperty(value = "none")
           None,
@@ -92,7 +92,7 @@ class RamlEnumTypesTest {
           @JsonProperty(value = "invalid:char")
           InvalidChar,
         }
-        
+
       """.trimIndent(),
       buildString {
         FileSpec.get("io.test", typeSpec)

--- a/generator/src/test/kotlin/io/outfoxx/sunday/generator/kotlin/RamlScalarTypesTest.kt
+++ b/generator/src/test/kotlin/io/outfoxx/sunday/generator/kotlin/RamlScalarTypesTest.kt
@@ -62,7 +62,7 @@ class RamlScalarTypesTest {
 
           public val nil: Unit
         }
-        
+
       """.trimIndent(),
       buildString {
         FileSpec.get("io.test", typeSpec)
@@ -101,10 +101,10 @@ class RamlScalarTypesTest {
           public val int: Int
 
           public val long: Long
-        
+
           public val none: Int
         }
-        
+
       """.trimIndent(),
       buildString {
         FileSpec.get("io.test", typeSpec)
@@ -125,7 +125,7 @@ class RamlScalarTypesTest {
     assertEquals(
       """
         package io.test
-        
+
         import kotlin.Double
         import kotlin.Float
 
@@ -133,10 +133,10 @@ class RamlScalarTypesTest {
           public val float: Float
 
           public val double: Double
-        
+
           public val none: Double
         }
-        
+
       """.trimIndent(),
       buildString {
         FileSpec.get("io.test", typeSpec)
@@ -165,14 +165,14 @@ class RamlScalarTypesTest {
 
         public interface Test {
           public val dateOnly: LocalDate
-        
+
           public val timeOnly: LocalTime
-        
+
           public val dateTimeOnly: LocalDateTime
-        
+
           public val dateTime: OffsetDateTime
         }
-        
+
       """.trimIndent(),
       buildString {
         FileSpec.get("io.test", typeSpec)

--- a/gradle-plugin/src/main/kotlin/io/outfoxx/sunday/generator/gradle/SundayGenerate.kt
+++ b/gradle-plugin/src/main/kotlin/io/outfoxx/sunday/generator/gradle/SundayGenerate.kt
@@ -138,6 +138,10 @@ open class SundayGenerate
   @Optional
   val useResultResponseReturn: Property<Boolean> = objects.property(Boolean::class.java)
 
+  @Input
+  @Optional
+  val useJakartaPackages: Property<Boolean> = objects.property(Boolean::class.java)
+
   @OutputDirectory
   val outputDir: Property<Directory> = objects.directoryProperty()
 
@@ -182,6 +186,9 @@ open class SundayGenerate
     }
     if (disableValidationConstraints.getOrElse(false)) {
       options.remove(ValidationConstraints)
+    }
+    if (!useJakartaPackages.getOrElse(false)) {
+      options.remove(KotlinTypeRegistry.Option.UseJakartaPackages)
     }
 
     val typeRegistry = KotlinTypeRegistry(modelPkgName, generatedAnnotation.orNull, mode, options)

--- a/gradle-plugin/src/main/kotlin/io/outfoxx/sunday/generator/gradle/SundayGeneration.kt
+++ b/gradle-plugin/src/main/kotlin/io/outfoxx/sunday/generator/gradle/SundayGeneration.kt
@@ -58,6 +58,7 @@ class SundayGeneration(
   val generatedAnnotation: Property<String> = objects.property(String::class.java)
   val alwaysUseResponseReturn: Property<Boolean> = objects.property(Boolean::class.java)
   val useResultResponseReturn: Property<Boolean> = objects.property(Boolean::class.java)
+  val useJakartaPackages: Property<Boolean> = objects.property(Boolean::class.java)
   val outputDir: Property<Directory> = objects.directoryProperty().convention(outputDirDef)
   val targetSourceSet: Property<String> = objects.property(String::class.java).convention(MAIN_SOURCE_SET_NAME)
 }

--- a/gradle-plugin/src/main/kotlin/io/outfoxx/sunday/generator/gradle/SundayGeneratorPlugin.kt
+++ b/gradle-plugin/src/main/kotlin/io/outfoxx/sunday/generator/gradle/SundayGeneratorPlugin.kt
@@ -57,6 +57,7 @@ class SundayGeneratorPlugin : Plugin<Project> {
         genTask.generatedAnnotation.set(gen.generatedAnnotation)
         genTask.alwaysUseResponseReturn.set(gen.alwaysUseResponseReturn)
         genTask.useResultResponseReturn.set(gen.useResultResponseReturn)
+        genTask.useJakartaPackages.set(gen.useJakartaPackages)
         genTask.outputDir.set(gen.outputDir)
       }
 

--- a/gradle-plugin/src/test/kotlin/io/outfoxx/sunday/generator/gradle/tests/GradlePluginTests.kt
+++ b/gradle-plugin/src/test/kotlin/io/outfoxx/sunday/generator/gradle/tests/GradlePluginTests.kt
@@ -72,7 +72,7 @@ class GradlePluginTests {
       }
 
       sundayGenerations {
-        client { 
+        client {
           framework.set(Sunday)
           mode.set(Client)
           modelPkgName.set('io.outfoxx.test.client.model')
@@ -92,7 +92,7 @@ class GradlePluginTests {
         implementation "javax.validation:validation-api:1.1.0.Final"
         implementation "com.fasterxml.jackson.core:jackson-databind:2.10.0"
       }
-      
+
       compileKotlin {
         kotlinOptions {
           jvmTarget = "11"

--- a/gradle.properties
+++ b/gradle.properties
@@ -26,13 +26,6 @@ dockerJavaVersion=3.2.13
 
 sundayKtVersion=1.0.0-beta.18
 kotlinCoroutinesVersion=1.6.4
-jaxrsVersion=2.0.2.Final
-validationVersion=2.0.1.Final
-zalandoProblemVersion=0.27.1
-jacksonVersion=2.12.3
-mutinyVersion=1.7.0
-rxJava3Version=3.1.5
-rxJava2Version=2.2.21
 
 amfClientVersion=5.2.0
 cliktVersion=3.5.0
@@ -42,3 +35,14 @@ swiftPoetVersion=1.5.0
 
 jcolorVersion=5.0.1
 jimfsVersion=1.2
+
+
+# generate code dependencies
+jakartaJaxrsVersion=3.1.0
+javaxJaxrsVersion=2.0.2.Final
+validationVersion=2.0.1.Final
+zalandoProblemVersion=0.27.1
+jacksonVersion=2.12.3
+mutinyVersion=1.7.0
+rxJava3Version=3.1.5
+rxJava2Version=2.2.21


### PR DESCRIPTION
Adds suport for generating for Jakarta EE or Java EE pacakges. When targeting JAX-RS or usins Jakarta Bean Validation.

*Additionally*, this removes all dependencies for generated code from the generator’s dependencies. These have been replaced with hardcoded (and when needed selectable) type names.

## Enabling Option

### CLI
Add `-enable use-jackarta-packages`

### Gradle
`useJakartaPacakges.set(true)`