### PR TITLE
Support InboundSseEvent & OutboundSseEvent from Flow

### DIFF
--- a/generator/build.gradle.kts
+++ b/generator/build.gradle.kts
@@ -82,6 +82,12 @@ dependencies {
   testImplementation("com.google.jimfs:jimfs:$jimfsVersion")
 }
 
+tasks {
+  javadoc {
+    include("io/outfoxx/**")
+  }
+}
+
 publishing {
   publications {
     create<MavenPublication>("generator") {

--- a/generator/src/main/java/org/jboss/resteasy/reactive/RestStreamElementType.java
+++ b/generator/src/main/java/org/jboss/resteasy/reactive/RestStreamElementType.java
@@ -6,9 +6,6 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-/**
- * @hidden
- */
 @Inherited
 @Target({ ElementType.TYPE, ElementType.METHOD })
 @Retention(RetentionPolicy.RUNTIME)

--- a/generator/src/main/kotlin/io/outfoxx/sunday/generator/kotlin/utils/JaxRsTypes.kt
+++ b/generator/src/main/kotlin/io/outfoxx/sunday/generator/kotlin/utils/JaxRsTypes.kt
@@ -43,6 +43,8 @@ class JaxRsTypes(basePackage: String) {
   val sse = ClassName.bestGuess("$basePackage.ws.rs.sse.Sse")
   val sseEventSink = ClassName.bestGuess("$basePackage.ws.rs.sse.SseEventSink")
   val sseEventSource = ClassName.bestGuess("$basePackage.ws.rs.sse.SseEventSource")
+  val sseInboundEvent = ClassName.bestGuess("$basePackage.ws.rs.sse.InboundSseEvent")
+  val sseOutboundEvent = ClassName.bestGuess("$basePackage.ws.rs.sse.OutboundSseEvent")
 
   fun httpMethod(methodName: String) =
     when (methodName.uppercase()) {

--- a/generator/src/test/kotlin/io/outfoxx/sunday/generator/kotlin/jaxrs/RequestCoroutineMethodsTest.kt
+++ b/generator/src/test/kotlin/io/outfoxx/sunday/generator/kotlin/jaxrs/RequestCoroutineMethodsTest.kt
@@ -284,7 +284,7 @@ class RequestCoroutineMethodsTest {
 
   @Test
   fun `test event coroutines method generation in server mode`(
-    @ResourceUri("raml/resource-gen/res-event-stream.raml") testUri: URI,
+    @ResourceUri("raml/resource-gen/res-event-stream-jaxrs.raml") testUri: URI,
   ) {
 
     val typeRegistry = KotlinTypeRegistry("io.test", null, GenerationMode.Server, setOf())
@@ -320,6 +320,7 @@ class RequestCoroutineMethodsTest {
         import javax.ws.rs.GET
         import javax.ws.rs.Path
         import javax.ws.rs.Produces
+        import javax.ws.rs.sse.OutboundSseEvent
         import kotlin.Any
         import kotlinx.coroutines.flow.Flow
 
@@ -335,6 +336,11 @@ class RequestCoroutineMethodsTest {
           @Path(value = "/test2")
           @Produces(value = ["text/event-stream"])
           public suspend fun fetchEventsDiscriminated(): Flow<Any>
+
+          @GET
+          @Path(value = "/test3")
+          @Produces(value = ["text/event-stream"])
+          public suspend fun fetchEventsSimpleSse(): Flow<OutboundSseEvent>
         }
 
       """.trimIndent(),
@@ -347,7 +353,7 @@ class RequestCoroutineMethodsTest {
 
   @Test
   fun `test event coroutines method generation in client mode`(
-    @ResourceUri("raml/resource-gen/res-event-stream.raml") testUri: URI,
+    @ResourceUri("raml/resource-gen/res-event-stream-jaxrs.raml") testUri: URI,
   ) {
 
     val typeRegistry = KotlinTypeRegistry("io.test", null, GenerationMode.Client, setOf())
@@ -383,6 +389,7 @@ class RequestCoroutineMethodsTest {
         import javax.ws.rs.GET
         import javax.ws.rs.Path
         import javax.ws.rs.Produces
+        import javax.ws.rs.sse.InboundSseEvent
         import kotlin.Any
         import kotlinx.coroutines.flow.Flow
 
@@ -398,6 +405,11 @@ class RequestCoroutineMethodsTest {
           @Path(value = "/test2")
           @Produces(value = ["text/event-stream"])
           public suspend fun fetchEventsDiscriminated(): Flow<Any>
+
+          @GET
+          @Path(value = "/test3")
+          @Produces(value = ["text/event-stream"])
+          public suspend fun fetchEventsSimpleSse(): Flow<InboundSseEvent>
         }
 
       """.trimIndent(),

--- a/generator/src/test/resources/raml/resource-gen/res-event-stream-jaxrs.raml
+++ b/generator/src/test/resources/raml/resource-gen/res-event-stream-jaxrs.raml
@@ -1,0 +1,57 @@
+#%RAML 1.0
+title: Test API
+uses:
+  sunday: https://outfoxx.github.io/sunday-generator/sunday.raml
+mediaType:
+- application/json
+
+types:
+
+  Test1:
+    type: object
+    properties:
+      type: string
+      value: string
+
+  Test2:
+    type: object
+    discriminatorValue: test2
+    properties:
+      value: string
+
+  Test3:
+    type: object
+    discriminatorValue: t3
+    properties:
+      value: string
+
+/test1:
+  get:
+    displayName: fetchEventsSimple
+    (sunday.eventStream): simple
+    responses:
+      200:
+        body:
+          text/event-stream:
+            type: Test1
+
+/test2:
+  get:
+    displayName: fetchEventsDiscriminated
+    (sunday.eventStream): discriminated
+    responses:
+      200:
+        body:
+          text/event-stream:
+            type: Test1 | Test2 | Test3
+
+/test3:
+  get:
+    displayName: fetchEventsSimpleSse
+    (sunday.eventStream): simple
+    (sunday.sse): true
+    responses:
+      200:
+        body:
+          text/event-stream:
+            type: Test1


### PR DESCRIPTION
Use `(sunday.eventStream): simple` and add  `(sunday.sse): true`, to output SSE event types instead of the selected event type