### PR TITLE
Allow subtypes to restate parent properties

### DIFF
--- a/generator/src/main/kotlin/io/outfoxx/sunday/generator/swift/SwiftTypeRegistry.kt
+++ b/generator/src/main/kotlin/io/outfoxx/sunday/generator/swift/SwiftTypeRegistry.kt
@@ -572,6 +572,7 @@ class SwiftTypeRegistry(
     var inheritedDeclaredProperties = originalInheritedDeclaredProperties
 
     val originalLocalProperties = context.findProperties(shape)
+      .filter { prop -> prop.name !in originalInheritedProperties.map { it.name } }
     var localProperties = originalLocalProperties
     val originalLocalDeclaredProperties = localProperties.filterNot { it.range.hasAnnotation(SwiftImpl, null) }
     var localDeclaredProperties = originalLocalDeclaredProperties

--- a/generator/src/main/kotlin/io/outfoxx/sunday/generator/typescript/TypeScriptTypeRegistry.kt
+++ b/generator/src/main/kotlin/io/outfoxx/sunday/generator/typescript/TypeScriptTypeRegistry.kt
@@ -582,6 +582,7 @@ class TypeScriptTypeRegistry(
 
     var inheritedProperties = superShape?.let(context::findAllProperties) ?: emptyList()
     var declaredProperties = context.findProperties(shape)
+      .filter { prop -> prop.name !in inheritedProperties.map { it.name } }
 
     val inheritingTypes = context.findInheritingShapes(shape).map { it as NodeShape }
 

--- a/generator/src/test/resources/raml/type-gen/types/obj-inherits.raml
+++ b/generator/src/test/resources/raml/type-gen/types/obj-inherits.raml
@@ -19,6 +19,7 @@ types:
   Test3:
     type: Empty
     properties:
+      value2: string
       value3: string
 
 


### PR DESCRIPTION
RAML _should_ take care of ensuring compatibility