### PR TITLE
More fixes for inheritance with patchable types

### DIFF
--- a/generator/src/main/kotlin/io/outfoxx/sunday/generator/kotlin/KotlinTypeRegistry.kt
+++ b/generator/src/main/kotlin/io/outfoxx/sunday/generator/kotlin/KotlinTypeRegistry.kt
@@ -929,7 +929,7 @@ class KotlinTypeRegistry(
       }
     }
 
-    if (isPatchable && options.contains(ImplementModel)) {
+    if (isPatchable && options.contains(ImplementModel) && !typeBuilder.modifiers.contains(KModifier.ABSTRACT)) {
 
       val initLambdaTypeName = LambdaTypeName.get(className, listOf(), UNIT)
 

--- a/generator/src/test/resources/raml/type-gen/annotations/type-patchable-disc.raml
+++ b/generator/src/test/resources/raml/type-gen/annotations/type-patchable-disc.raml
@@ -1,0 +1,34 @@
+#%RAML 1.0
+title: Test API
+uses:
+  sunday: https://outfoxx.github.io/sunday-generator/sunday.raml
+mediaType:
+- application/json
+
+types:
+
+  TestType:
+    type: string
+    enum: [ child ]
+
+  Test:
+    type: object
+    (sunday.patchable): true
+    discriminator: type
+    properties:
+      type: TestType
+
+  Child:
+    type: Test
+    discriminatorValue: child
+    properties:
+      child: string
+
+/tests/{id}:
+
+  get:
+    displayName: fetchTest
+    responses:
+      200:
+        body:
+          type: Test

--- a/generator/src/test/resources/swift/compile/local/Package.swift
+++ b/generator/src/test/resources/swift/compile/local/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
         .library(name: "SundayGenTest", targets: ["SundayGenTest"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/outfoxx/sunday-swift.git", from: "1.0.0-beta.16")
+        .package(url: "https://github.com/outfoxx/sunday-swift.git", from: "1.0.0")
     ],
     targets: [
         .target(


### PR DESCRIPTION
This pull request includes several changes to the Kotlin and Swift type registries, as well as updates to the test cases and resources. The most important changes involve improvements to patchable class generation and the addition of new test cases for discriminated patchable class generation.

Improvements to patchable class generation:

* [`generator/src/main/kotlin/io/outfoxx/sunday/generator/kotlin/KotlinTypeRegistry.kt`](diffhunk://#diff-6c03fc84e9ef317acbc72ebb119f2b55f016f730c1823dd9983d08469ecb2156L932-R932): Modified the condition to check if a class is patchable and should implement a model to exclude abstract classes.
* [`generator/src/main/kotlin/io/outfoxx/sunday/generator/swift/SwiftTypeRegistry.kt`](diffhunk://#diff-251a72d240547279bd3b026a99b7e88b9eec214e7cc49f3d45ea62ba2ab9e8efL1277-R1287): Updated the property handling in patchable classes to use a map of property names to property types, improving code clarity and maintainability. [[1]](diffhunk://#diff-251a72d240547279bd3b026a99b7e88b9eec214e7cc49f3d45ea62ba2ab9e8efL1277-R1287) [[2]](diffhunk://#diff-251a72d240547279bd3b026a99b7e88b9eec214e7cc49f3d45ea62ba2ab9e8efL1288-R1299) [[3]](diffhunk://#diff-251a72d240547279bd3b026a99b7e88b9eec214e7cc49f3d45ea62ba2ab9e8efL1300-R1309)

Additions to test cases:

* [`generator/src/test/kotlin/io/outfoxx/sunday/generator/kotlin/RamlTypeAnnotationsTest.kt`](diffhunk://#diff-ddab63f37620f970737f1ecc8cb02b5b2423a987937cd23c55f16773e7880754R1054-R1168): Added a new test case for discriminated patchable class generation, verifying the generated Kotlin code against expected output.
* [`generator/src/test/kotlin/io/outfoxx/sunday/generator/swift/RamlTypeAnnotationsTest.kt`](diffhunk://#diff-3e01f8933f241febde56eedadabab5545e3fdf1e09a9a2ce2a9551ab1cb7408fR1407-R1598): Added a new test case for discriminated patchable class generation, verifying the generated Swift code against expected output.
* [`generator/src/test/kotlin/io/outfoxx/sunday/generator/typescript/RamlTypeAnnotationsTest.kt`](diffhunk://#diff-b26b432ad556a3a3fa3395839d83693d804e8d8b2244d1f4500fed5f562b5129R1187-R1232): Added a new test case for discriminated patchable class generation with Jackson decorators, verifying the generated TypeScript code against expected output.

Updates to resources:

* [`generator/src/test/resources/raml/type-gen/annotations/type-patchable-disc.raml`](diffhunk://#diff-f7e93bb6141a785fb0f67b73fb7ff619ddc88152134f1b950f4110b3841334b4R1-R34): Added a new RAML resource for testing discriminated patchable class generation.

Dependency updates:

* [`generator/src/test/resources/swift/compile/local/Package.swift`](diffhunk://#diff-355c8dc4d8b377b466996bfe1f2d6150adc61770658f2b9261292a081ae82e8cL13-R13): Updated the dependency on `sunday-swift` to use version `1.0.0` instead of a beta version.