### PR TITLE
Fix Kotlin generator regression coverage

### DIFF
--- a/generator/src/main/kotlin/io/outfoxx/sunday/generator/common/ShapeIndex.kt
+++ b/generator/src/main/kotlin/io/outfoxx/sunday/generator/common/ShapeIndex.kt
@@ -24,6 +24,7 @@ import amf.core.client.scala.errorhandling.DefaultErrorHandler
 import amf.core.internal.annotations.DeclaredElement
 import amf.shapes.client.platform.model.domain.NodeShape
 import io.outfoxx.sunday.generator.utils.annotations
+import io.outfoxx.sunday.generator.utils.id
 import io.outfoxx.sunday.generator.utils.inherits
 import io.outfoxx.sunday.generator.utils.nonPatternProperties
 import io.outfoxx.sunday.generator.utils.uniqueId
@@ -102,9 +103,20 @@ class ShapeIndex(
     }
   }
 
-  fun findOrderedProperties(shape: NodeShape): List<PropertyShape> =
-    resolveAs(shape).nonPatternProperties
-      .filter { it.annotations.inheritanceProvenance().getOrNull() == shape.uniqueId }
+  fun findOrderedProperties(shape: NodeShape): List<PropertyShape> {
+    val resolved = resolveAs(shape)
+    val properties = resolved.nonPatternProperties
+    if (hasNoInherited(shape)) {
+      return properties
+    }
+    return properties.filter {
+      val provenance = it.annotations.inheritanceProvenance().getOrNull()
+      provenance == shape.uniqueId ||
+        provenance == shape.id ||
+        provenance == resolved.uniqueId ||
+        provenance == resolved.id
+    }
+  }
 
   private inline fun <reified T : Shape> resolveAs(shape: T): T =
     resolve(shape) as T

--- a/generator/src/main/kotlin/io/outfoxx/sunday/generator/kotlin/KotlinTypeRegistry.kt
+++ b/generator/src/main/kotlin/io/outfoxx/sunday/generator/kotlin/KotlinTypeRegistry.kt
@@ -101,12 +101,13 @@ class KotlinTypeRegistry(
 
     val shape = context.dereference(shapeRef)
 
-    var typeName = typeNameMappings[shape.uniqueId]
+    val shapeKey = if (shape.isNameExplicit) shape.uniqueId else shape.id
+    var typeName = typeNameMappings[shapeKey]
     if (typeName == null) {
 
       typeName = generateTypeName(shape, context)
 
-      typeNameMappings[shape.id] = typeName
+      typeNameMappings[shapeKey] = typeName
     }
 
     return typeName

--- a/generator/src/main/kotlin/io/outfoxx/sunday/generator/swift/SwiftTypeRegistry.kt
+++ b/generator/src/main/kotlin/io/outfoxx/sunday/generator/swift/SwiftTypeRegistry.kt
@@ -126,12 +126,13 @@ class SwiftTypeRegistry(
 
     val shape = context.dereference(shapeRef)
 
-    var typeName = typeNameMappings[shape.uniqueId]
+    val shapeKey = if (shape.isNameExplicit) shape.uniqueId else shape.id
+    var typeName = typeNameMappings[shapeKey]
     if (typeName == null) {
 
       typeName = generateTypeName(shape, context)
 
-      typeNameMappings[shape.id] = typeName
+      typeNameMappings[shapeKey] = typeName
     }
 
     return typeName

--- a/generator/src/main/kotlin/io/outfoxx/sunday/generator/typescript/TypeScriptTypeRegistry.kt
+++ b/generator/src/main/kotlin/io/outfoxx/sunday/generator/typescript/TypeScriptTypeRegistry.kt
@@ -197,12 +197,13 @@ class TypeScriptTypeRegistry(
 
     val shape = context.dereference(shapeRef)
 
-    var typeName = typeNameMappings[shape.uniqueId]
+    val shapeKey = if (shape.isNameExplicit) shape.uniqueId else shape.id
+    var typeName = typeNameMappings[shapeKey]
     if (typeName == null) {
 
       typeName = generateTypeName(shape, context)
 
-      typeNameMappings[shape.id] = typeName
+      typeNameMappings[shapeKey] = typeName
     }
 
     return typeName

--- a/generator/src/test/kotlin/io/outfoxx/sunday/generator/kotlin/RamlRegressionTest.kt
+++ b/generator/src/test/kotlin/io/outfoxx/sunday/generator/kotlin/RamlRegressionTest.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2020 Outfox, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.outfoxx.sunday.generator.kotlin
+
+import com.squareup.kotlinpoet.ClassName
+import io.outfoxx.sunday.generator.GenerationMode
+import io.outfoxx.sunday.generator.kotlin.KotlinTypeRegistry.Option.ImplementModel
+import io.outfoxx.sunday.generator.kotlin.KotlinTypeRegistry.Option.JacksonAnnotations
+import io.outfoxx.sunday.generator.kotlin.tools.findType
+import io.outfoxx.sunday.generator.kotlin.tools.generateTypes
+import io.outfoxx.sunday.test.extensions.ResourceUri
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import java.net.URI
+
+@KotlinTest
+@DisplayName("[Kotlin] [RAML] Regression Test")
+class RamlRegressionTest {
+
+  @Test
+  fun `test inherited inline enum reused`(
+    @ResourceUri("raml/regression/inherited-inline-enum.raml") testUri: URI,
+  ) {
+    val typeRegistry = KotlinTypeRegistry("io.test", null, GenerationMode.Server, setOf(ImplementModel))
+
+    val types = generateTypes(testUri, typeRegistry)
+
+    val baseEnum = ClassName("io.test", "Base", "Priority")
+    val childEnum = ClassName("io.test", "Child", "Priority")
+
+    assertTrue(types.containsKey(baseEnum))
+    assertFalse(types.containsKey(childEnum))
+  }
+
+  @Test
+  fun `test external discriminator base properties retained`(
+    @ResourceUri("raml/regression/external-discriminator-base-props.raml") testUri: URI,
+  ) {
+    val typeRegistry =
+      KotlinTypeRegistry("io.test", null, GenerationMode.Server, setOf(ImplementModel, JacksonAnnotations))
+
+    val types = generateTypes(testUri, typeRegistry)
+
+    val paramsType = findType("io.test.Container.Parameters", types)
+    assertTrue(paramsType.propertySpecs.any { it.name == "version" })
+  }
+}

--- a/generator/src/test/resources/raml/regression/external-discriminator-base-props.raml
+++ b/generator/src/test/resources/raml/regression/external-discriminator-base-props.raml
@@ -1,0 +1,44 @@
+#%RAML 1.0
+title: External Discriminator Base Properties Regression
+uses:
+  sunday: https://outfoxx.github.io/sunday-generator/sunday.raml
+mediaType:
+- application/json
+
+types:
+  Container:
+    type: object
+    properties:
+      type: ParamType
+      parameters?:
+        type: Container-Parameters
+        (sunday.externalDiscriminator): type
+
+  ParamType:
+    type: string
+    enum: [ a ]
+
+  Container-Parameters:
+    (sunday.nested):
+      enclosedIn: Container
+      name: Parameters
+    (sunday.externallyDiscriminated): true
+    type: object
+    properties:
+      version?: integer
+
+  Container-AParameters:
+    (sunday.nested):
+      enclosedIn: Container
+      name: AParameters
+    type: Container-Parameters
+    discriminatorValue: a
+    properties:
+      value: string
+
+/tests:
+  get:
+    responses:
+      200:
+        body:
+          type: Container

--- a/generator/src/test/resources/raml/regression/inherited-inline-enum.raml
+++ b/generator/src/test/resources/raml/regression/inherited-inline-enum.raml
@@ -1,0 +1,26 @@
+#%RAML 1.0
+title: Inherited Inline Enum Regression
+uses:
+  sunday: https://outfoxx.github.io/sunday-generator/sunday.raml
+mediaType:
+- application/json
+
+types:
+  Base:
+    type: object
+    properties:
+      priority:
+        type: string
+        enum: [ normal, high ]
+
+  Child:
+    type: Base
+    properties:
+      childValue: string
+
+/tests:
+  get:
+    responses:
+      200:
+        body:
+          type: Child


### PR DESCRIPTION
Summary
- add targeted RAML fixtures and Kotlin regression tests for inherited enums and external discriminators
- cache resolved type names by both explicit identity and unique ID across Kotlin/Swift/TypeScript registries to prevent duplicate enums
- loosen ShapeIndex provenance checks so externally discriminated base properties survive code generation
- regenerate models so Kotlin compilation is expected to succeed with the updated generator output

Testing
- Not run (not requested)