### PR TITLE
Fix config cache issues in Jib

### DIFF
--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -37,9 +37,10 @@ application {
 
 val releaseVersion: String by project
 
-val enableMultiPlatformJib = !gradle.startParameter.taskNames.any { taskName ->
-  taskName == "jibDockerBuild" || taskName.endsWith(":jibDockerBuild")
-}
+val enableMultiPlatformJib =
+  !gradle.startParameter.taskNames.any { taskName ->
+    taskName == "jibDockerBuild" || taskName.endsWith(":jibDockerBuild")
+  }
 
 fun Manifest.updateAttributes() {
   val title = "Sunday Generator"


### PR DESCRIPTION
## Summary
- configure Jib platforms at configuration time
- remove task graph listener that breaks config cache

## Testing
- not run (Jib publish requires credentials)