### PR TITLE
Fix publish-release GIT_COMMIT_SHA env

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -39,7 +39,7 @@ jobs:
         build :dokkaGenerate
         -x test
       env:
-        GIT_COMMIT_SHA: ${{ env.GIT_COMMIT_SHORT_SHA }}
+        GIT_COMMIT_SHA: ${{ env.GIT_COMMIT_SHA }}
 
     - name: Publish Maven Release
       run: >-


### PR DESCRIPTION
## Summary
- use the GIT_COMMIT_SHA env set in the workflow instead of a missing GIT_COMMIT_SHORT_SHA

## Testing
- not run (workflow change)