### PR TITLE
Fix Gradle plugin caching and include discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Gradle Plugin Cache Notes
 
 - The Gradle plugin now defaults to deterministic output for build/cache correctness by omitting generated timestamps unless explicitly set.
 - Includes are discovered by parsing RAML sources; changes in nested include chains are tracked automatically.
+- The `includes` DSL property is deprecated and has no effect.
 - To opt in to a timestamp, set `generationTimestamp` on a generation (for example, a fixed string or a time you compute in the build script).
 
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,13 @@ Code generator for Sunday client libraries and standard server libraries.
 
 ### [Read the Documentation](https://outfoxx.github.io/sunday)
 
+Gradle Plugin Cache Notes
+-------------------------
+
+- The Gradle plugin now defaults to deterministic output for build/cache correctness by omitting generated timestamps unless explicitly set.
+- Included RAML fragments under `src/main/sunday-includes/**/*.raml` are tracked by default. Override with `includes.set(...)` in `sundayGenerations` if you use a different layout.
+- To opt in to a timestamp, set `generationTimestamp` on a generation (for example, a fixed string or a time you compute in the build script).
+
 
 License
 -------

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Gradle Plugin Cache Notes
 -------------------------
 
 - The Gradle plugin now defaults to deterministic output for build/cache correctness by omitting generated timestamps unless explicitly set.
-- Included RAML fragments under `src/main/sunday-includes/**/*.raml` are tracked by default. Override with `includes.set(...)` in `sundayGenerations` if you use a different layout.
+- Includes are discovered by parsing RAML sources; changes in nested include chains are tracked automatically.
 - To opt in to a timestamp, set `generationTimestamp` on a generation (for example, a fixed string or a time you compute in the build script).
 
 

--- a/generator/src/main/kotlin/io/outfoxx/sunday/generator/kotlin/KotlinTypeRegistry.kt
+++ b/generator/src/main/kotlin/io/outfoxx/sunday/generator/kotlin/KotlinTypeRegistry.kt
@@ -177,6 +177,7 @@ class KotlinTypeRegistry(
   val problemLibrary: KotlinProblemLibrary = KotlinProblemLibrary.QUARKUS,
   problemRfc: KotlinProblemRfc = KotlinProblemRfc.RFC9457,
   val validateProblemRfc: Boolean = false,
+  generationTimestamp: String? = LocalDateTime.now().format(ISO_LOCAL_DATE_TIME),
 ) : TypeRegistry {
 
   enum class Option {
@@ -189,7 +190,7 @@ class KotlinTypeRegistry(
     UseJakartaPackages,
   }
 
-  val generationTimestamp = LocalDateTime.now().format(ISO_LOCAL_DATE_TIME)!!
+  val generationTimestamp = generationTimestamp?.ifBlank { null }
   private val generatedAnnotationName = ClassName.bestGuess(generatedAnnotationName ?: Generated::class.qualifiedName!!)
   private val typeBuilders = mutableMapOf<ClassName, TypeSpec.Builder>()
   private val typeNameMappings = mutableMapOf<String, TypeName>()
@@ -1748,7 +1749,9 @@ class KotlinTypeRegistry(
           .apply {
             if (verbose) {
               addMember("value = [%S]", this@KotlinTypeRegistry.javaClass.name)
-              addMember("date = %S", generationTimestamp)
+              if (generationTimestamp != null) {
+                addMember("date = %S", generationTimestamp)
+              }
             }
           }.build(),
       )

--- a/gradle-plugin/src/main/kotlin/io/outfoxx/sunday/generator/gradle/SundayDiscoverIncludes.kt
+++ b/gradle-plugin/src/main/kotlin/io/outfoxx/sunday/generator/gradle/SundayDiscoverIncludes.kt
@@ -21,7 +21,6 @@ package io.outfoxx.sunday.generator.gradle
 import io.outfoxx.sunday.generator.common.APIProcessor
 import io.outfoxx.sunday.generator.utils.allUnits
 import io.outfoxx.sunday.generator.utils.location
-import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.FileCollection
 import org.gradle.api.file.FileTree
 import org.gradle.api.file.RegularFileProperty
@@ -54,12 +53,7 @@ abstract class SundayDiscoverIncludes
     @InputFiles
     @PathSensitive(PathSensitivity.RELATIVE)
     @Optional
-    val extraIncludes: Property<FileCollection> = objects.property(FileCollection::class.java)
-
-    @InputFiles
-    @PathSensitive(PathSensitivity.RELATIVE)
-    @Optional
-    val bootstrapIncludes: ConfigurableFileCollection = objects.fileCollection()
+    val bootstrapIncludes: Property<FileCollection> = objects.property(FileCollection::class.java)
 
     @OutputFile
     val includesIndexFile: RegularFileProperty = objects.fileProperty()
@@ -70,8 +64,7 @@ abstract class SundayDiscoverIncludes
     fun discover() {
       val roots = mutableSetOf<File>()
       roots.addAll(source.files)
-      extraIncludes.orNull?.files?.let { roots.addAll(it) }
-      roots.addAll(bootstrapIncludes.files)
+      bootstrapIncludes.orNull?.files?.let { roots.addAll(it) }
 
       val includes = mutableSetOf<File>()
 

--- a/gradle-plugin/src/main/kotlin/io/outfoxx/sunday/generator/gradle/SundayDiscoverIncludes.kt
+++ b/gradle-plugin/src/main/kotlin/io/outfoxx/sunday/generator/gradle/SundayDiscoverIncludes.kt
@@ -76,30 +76,30 @@ abstract class SundayDiscoverIncludes
       val includes = mutableSetOf<File>()
 
       roots.forEach { file ->
-          val processed = apiProcessor.process(file.toURI())
-          processed.validationLog.forEach {
-            val level =
-              when (it.level) {
-                APIProcessor.Result.Level.Error -> LogLevel.ERROR
-                APIProcessor.Result.Level.Warning -> LogLevel.WARN
-                APIProcessor.Result.Level.Info -> LogLevel.INFO
-              }
-            logger.log(level, "${it.file}:${it.line}: ${it.message}")
-          }
-
-          processed
-            .document
-            .allUnits
-            .mapNotNull { unit -> unit.location }
-            .mapNotNull { location ->
-              when {
-                location.startsWith("file:", ignoreCase = true) -> runCatching { File(URI(location)) }.getOrNull()
-                location.isNotBlank() -> File(location)
-                else -> null
-              }
-            }.filter { it.exists() }
-            .forEach { includes.add(it.canonicalFile) }
+        val processed = apiProcessor.process(file.toURI())
+        processed.validationLog.forEach {
+          val level =
+            when (it.level) {
+              APIProcessor.Result.Level.Error -> LogLevel.ERROR
+              APIProcessor.Result.Level.Warning -> LogLevel.WARN
+              APIProcessor.Result.Level.Info -> LogLevel.INFO
+            }
+          logger.log(level, "${it.file}:${it.line}: ${it.message}")
         }
+
+        processed
+          .document
+          .allUnits
+          .mapNotNull { unit -> unit.location }
+          .mapNotNull { location ->
+            when {
+              location.startsWith("file:", ignoreCase = true) -> runCatching { File(URI(location)) }.getOrNull()
+              location.isNotBlank() -> File(location)
+              else -> null
+            }
+          }.filter { it.exists() }
+          .forEach { includes.add(it.canonicalFile) }
+      }
 
       val outputFile = includesIndexFile.get().asFile
       outputFile.parentFile.mkdirs()

--- a/gradle-plugin/src/main/kotlin/io/outfoxx/sunday/generator/gradle/SundayDiscoverIncludes.kt
+++ b/gradle-plugin/src/main/kotlin/io/outfoxx/sunday/generator/gradle/SundayDiscoverIncludes.kt
@@ -68,7 +68,9 @@ abstract class SundayDiscoverIncludes
             return@filter false
           }
           val header = file.bufferedReader().use { it.readLine() }?.trim() ?: return@filter false
-          header.startsWith("#%RAML 1.0")
+          header == "#%RAML 1.0" ||
+            header.startsWith("#%RAML 1.0 Overlay") ||
+            header.startsWith("#%RAML 1.0 Extension")
         }
 
       val includes = mutableSetOf<File>()

--- a/gradle-plugin/src/main/kotlin/io/outfoxx/sunday/generator/gradle/SundayDiscoverIncludes.kt
+++ b/gradle-plugin/src/main/kotlin/io/outfoxx/sunday/generator/gradle/SundayDiscoverIncludes.kt
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2020 Outfox, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UnstableApiUsage")
+
+package io.outfoxx.sunday.generator.gradle
+
+import io.outfoxx.sunday.generator.common.APIProcessor
+import io.outfoxx.sunday.generator.utils.allUnits
+import io.outfoxx.sunday.generator.utils.location
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.FileCollection
+import org.gradle.api.file.FileTree
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.logging.LogLevel
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.SourceTask
+import org.gradle.api.tasks.TaskAction
+import java.io.File
+import java.net.URI
+import javax.inject.Inject
+
+@CacheableTask
+abstract class SundayDiscoverIncludes
+  @Inject
+  constructor(
+    objects: ObjectFactory,
+  ) : SourceTask() {
+
+    @InputFiles
+    @PathSensitive(PathSensitivity.RELATIVE)
+    override fun getSource(): FileTree = super.getSource()
+
+    @InputFiles
+    @PathSensitive(PathSensitivity.RELATIVE)
+    @Optional
+    val extraIncludes: Property<FileCollection> = objects.property(FileCollection::class.java)
+
+    @InputFiles
+    @PathSensitive(PathSensitivity.RELATIVE)
+    @Optional
+    val bootstrapIncludes: ConfigurableFileCollection = objects.fileCollection()
+
+    @OutputFile
+    val includesIndexFile: RegularFileProperty = objects.fileProperty()
+
+    private val apiProcessor = APIProcessor()
+
+    @TaskAction
+    fun discover() {
+      val roots = mutableSetOf<File>()
+      roots.addAll(source.files)
+      extraIncludes.orNull?.files?.let { roots.addAll(it) }
+      roots.addAll(bootstrapIncludes.files)
+
+      val includes = mutableSetOf<File>()
+
+      roots
+        .filter { it.isFile && it.extension == "raml" }
+        .forEach { file ->
+          val processed = apiProcessor.process(file.toURI())
+          processed.validationLog.forEach {
+            val level =
+              when (it.level) {
+                APIProcessor.Result.Level.Error -> LogLevel.ERROR
+                APIProcessor.Result.Level.Warning -> LogLevel.WARN
+                APIProcessor.Result.Level.Info -> LogLevel.INFO
+              }
+            logger.log(level, "${it.file}:${it.line}: ${it.message}")
+          }
+
+          processed
+            .document
+            .allUnits
+            .mapNotNull { unit -> unit.location }
+            .mapNotNull { location ->
+              when {
+                location.startsWith("file:", ignoreCase = true) -> runCatching { File(URI(location)) }.getOrNull()
+                location.isNotBlank() -> File(location)
+                else -> null
+              }
+            }.filter { it.exists() }
+            .forEach { includes.add(it.canonicalFile) }
+        }
+
+      val outputFile = includesIndexFile.get().asFile
+      outputFile.parentFile.mkdirs()
+      outputFile.writeText(
+        includes
+          .map { it.absolutePath }
+          .sorted()
+          .joinToString("\n"),
+      )
+    }
+  }

--- a/gradle-plugin/src/main/kotlin/io/outfoxx/sunday/generator/gradle/SundayGenerate.kt
+++ b/gradle-plugin/src/main/kotlin/io/outfoxx/sunday/generator/gradle/SundayGenerate.kt
@@ -42,6 +42,7 @@ import org.gradle.api.provider.Property
 import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.PathSensitive
@@ -63,124 +64,134 @@ abstract class SundayGenerate
     @PathSensitive(PathSensitivity.RELATIVE)
     override fun getSource(): FileTree = super.getSource()
 
-    @InputFiles
-    @PathSensitive(PathSensitivity.RELATIVE)
-    @Optional
+    @get:InputFiles
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    @get:Optional
     val includes: Property<FileCollection> = objects.property(FileCollection::class.java)
 
-    @Input
+    @get:Input
     val framework: Property<TargetFramework> = objects.property(TargetFramework::class.java)
 
-    @Input
+    @get:Input
     val mode: Property<GenerationMode> = objects.property(GenerationMode::class.java)
 
-    @Input
-    @Optional
+    @get:Input
+    @get:Optional
     val generateModel: Property<Boolean> = objects.property(Boolean::class.java).convention(true)
 
-    @Input
-    @Optional
+    @get:Input
+    @get:Optional
     val generateService: Property<Boolean> = objects.property(Boolean::class.java).convention(true)
 
-    @Input
-    @Optional
+    @get:Input
+    @get:Optional
     val pkgName: Property<String> = objects.property(String::class.java).convention("com.example")
 
-    @Input
-    @Optional
+    @get:Input
+    @get:Optional
     val modelPkgName: Property<String> = objects.property(String::class.java).convention(pkgName)
 
-    @Input
-    @Optional
+    @get:Input
+    @get:Optional
     val servicePkgName: Property<String> = objects.property(String::class.java).convention(pkgName)
 
-    @Input
-    @Optional
+    @get:Input
+    @get:Optional
     val serviceSuffix: Property<String> = objects.property(String::class.java).convention("API")
 
-    @Input
-    @Optional
+    @get:Input
+    @get:Optional
     val problemBaseUri: Property<String> = objects.property(String::class.java).convention("http://example.com/")
 
-    @Input
-    @Optional
+    @get:Input
+    @get:Optional
     val disableValidationConstraints: Property<Boolean> = objects.property(Boolean::class.java).convention(false)
 
-    @Input
-    @Optional
+    @get:Input
+    @get:Optional
     val disableContainerElementValid: Property<Boolean> = objects.property(Boolean::class.java).convention(false)
 
-    @Input
-    @Optional
+    @get:Input
+    @get:Optional
     val disableJacksonAnnotations: Property<Boolean> = objects.property(Boolean::class.java).convention(false)
 
-    @Input
-    @Optional
+    @get:Input
+    @get:Optional
     val disableModelImplementations: Property<Boolean> = objects.property(Boolean::class.java).convention(false)
 
-    @Input
-    @Optional
+    @get:Input
+    @get:Optional
     val coroutines: Property<Boolean> = objects.property(Boolean::class.java).convention(false)
 
-    @Input
-    @Optional
+    @get:Input
+    @get:Optional
     val flowCoroutines: Property<Boolean> = objects.property(Boolean::class.java).convention(false)
 
-    @Input
-    @Optional
+    @get:Input
+    @get:Optional
     val reactiveResponseType: Property<String> = objects.property(String::class.java).convention(null as String?)
 
-    @Input
-    @Optional
+    @get:Input
+    @get:Optional
     val explicitSecurityParameters: Property<Boolean> = objects.property(Boolean::class.java).convention(false)
 
-    @Input
-    @Optional
+    @get:Input
+    @get:Optional
     val baseUriMode: Property<BaseUriMode> = objects.property(BaseUriMode::class.java).convention(null as BaseUriMode?)
 
-    @Input
-    @Optional
+    @get:Input
+    @get:Optional
     val defaultMediaTypes: ListProperty<String> = objects.listProperty(String::class.java).convention(listOf())
 
-    @Input
-    @Optional
+    @get:Input
+    @get:Optional
     val generatedAnnotation: Property<String> = objects.property(String::class.java).convention(null as String?)
 
-    @Input
-    @Optional
+    @get:Input
+    @get:Optional
+    val generationTimestamp: Property<String> = objects.property(String::class.java)
+
+    @get:Input
+    @get:Optional
     val alwaysUseResponseReturn: Property<Boolean> = objects.property(Boolean::class.java).convention(false)
 
-    @Input
-    @Optional
+    @get:Input
+    @get:Optional
     val useResultResponseReturn: Property<Boolean> = objects.property(Boolean::class.java).convention(false)
 
-    @Input
-    @Optional
+    @get:Input
+    @get:Optional
     val useJakartaPackages: Property<Boolean> = objects.property(Boolean::class.java).convention(false)
 
-    @Input
-    @Optional
+    @get:Input
+    @get:Optional
     val quarkus: Property<Boolean> = objects.property(Boolean::class.java).convention(false)
 
-    @Input
-    @Optional
+    @get:Input
+    @get:Optional
     val problemLibrary: Property<KotlinProblemLibrary> =
       objects
         .property(KotlinProblemLibrary::class.java)
         .convention(KotlinProblemLibrary.QUARKUS)
 
-    @Input
-    @Optional
+    @get:Input
+    @get:Optional
     val problemRfc: Property<KotlinProblemRfc> =
       objects
         .property(KotlinProblemRfc::class.java)
         .convention(KotlinProblemRfc.RFC9457)
 
-    @OutputDirectory
+    @get:OutputDirectory
     val outputDir: Property<Directory> =
       objects
         .directoryProperty()
         .convention(project.layout.buildDirectory.dir("generated/sources/sunday/$name"))
+
+    @get:Internal
+    val rootDir: Property<Directory> =
+      objects
+        .directoryProperty()
+        .convention(project.layout.projectDirectory)
 
     private val apiProcessor = APIProcessor()
 
@@ -232,6 +243,7 @@ abstract class SundayGenerate
           options,
           effectiveProblemLibrary,
           problemRfc.get(),
+          generationTimestamp = generationTimestamp.orNull,
         )
 
       source
@@ -257,7 +269,7 @@ abstract class SundayGenerate
             APIProcessor.Result.Level.Warning -> LogLevel.WARN
             APIProcessor.Result.Level.Info -> LogLevel.INFO
           }
-        val errorFile = File(it.file).relativeToOrSelf(project.rootDir)
+        val errorFile = File(it.file).relativeToOrSelf(rootDir.get().asFile)
         logger.log(level, "$errorFile:${it.line}: ${it.message}")
       }
 

--- a/gradle-plugin/src/main/kotlin/io/outfoxx/sunday/generator/gradle/SundayGeneration.kt
+++ b/gradle-plugin/src/main/kotlin/io/outfoxx/sunday/generator/gradle/SundayGeneration.kt
@@ -39,10 +39,7 @@ class SundayGeneration(
       .property(FileCollection::class.java)
       .convention(project.fileTree("src/main/sunday") { it.include("**/*.raml") })
 
-  val includes: Property<FileCollection> =
-    objects
-      .property(FileCollection::class.java)
-      .convention(project.fileTree("src/main/sunday-includes") { it.include("**/*.raml") })
+  val includes: Property<FileCollection> = objects.property(FileCollection::class.java)
   val framework: Property<TargetFramework> = objects.property(TargetFramework::class.java)
   val mode: Property<GenerationMode> = objects.property(GenerationMode::class.java)
   val generateModel: Property<Boolean> = objects.property(Boolean::class.java)

--- a/gradle-plugin/src/main/kotlin/io/outfoxx/sunday/generator/gradle/SundayGeneration.kt
+++ b/gradle-plugin/src/main/kotlin/io/outfoxx/sunday/generator/gradle/SundayGeneration.kt
@@ -39,7 +39,10 @@ class SundayGeneration(
       .property(FileCollection::class.java)
       .convention(project.fileTree("src/main/sunday") { it.include("**/*.raml") })
 
-  val includes: Property<FileCollection> = objects.property(FileCollection::class.java)
+  val includes: Property<FileCollection> =
+    objects
+      .property(FileCollection::class.java)
+      .convention(project.fileTree("src/main/sunday-includes") { it.include("**/*.raml") })
   val framework: Property<TargetFramework> = objects.property(TargetFramework::class.java)
   val mode: Property<GenerationMode> = objects.property(GenerationMode::class.java)
   val generateModel: Property<Boolean> = objects.property(Boolean::class.java)
@@ -59,6 +62,7 @@ class SundayGeneration(
   val baseUriMode: Property<BaseUriMode> = objects.property(BaseUriMode::class.java)
   val defaultMediaTypes: ListProperty<String> = objects.listProperty(String::class.java)
   val generatedAnnotation: Property<String> = objects.property(String::class.java)
+  val generationTimestamp: Property<String> = objects.property(String::class.java)
   val alwaysUseResponseReturn: Property<Boolean> = objects.property(Boolean::class.java)
   val useResultResponseReturn: Property<Boolean> = objects.property(Boolean::class.java)
   val useJakartaPackages: Property<Boolean> = objects.property(Boolean::class.java)

--- a/gradle-plugin/src/main/kotlin/io/outfoxx/sunday/generator/gradle/SundayGeneration.kt
+++ b/gradle-plugin/src/main/kotlin/io/outfoxx/sunday/generator/gradle/SundayGeneration.kt
@@ -39,7 +39,12 @@ class SundayGeneration(
       .property(FileCollection::class.java)
       .convention(project.fileTree("src/main/sunday") { it.include("**/*.raml") })
 
+  @Deprecated(
+    message = "Includes are discovered automatically; this property has no effect.",
+    level = DeprecationLevel.WARNING,
+  )
   val includes: Property<FileCollection> = objects.property(FileCollection::class.java)
+
   val framework: Property<TargetFramework> = objects.property(TargetFramework::class.java)
   val mode: Property<GenerationMode> = objects.property(GenerationMode::class.java)
   val generateModel: Property<Boolean> = objects.property(Boolean::class.java)

--- a/gradle-plugin/src/main/kotlin/io/outfoxx/sunday/generator/gradle/SundayGeneratorPlugin.kt
+++ b/gradle-plugin/src/main/kotlin/io/outfoxx/sunday/generator/gradle/SundayGeneratorPlugin.kt
@@ -39,13 +39,15 @@ class SundayGeneratorPlugin : Plugin<Project> {
       }
     project.extensions.add("sundayGenerations", generationsContainer)
 
+    val sourceSets = project.extensions.getByType(SourceSetContainer::class.java)
+
     generationsContainer.configureEach { gen ->
 
       val genTask =
         project.tasks.register("sundayGenerate_${gen.name}", SundayGenerate::class.java) { genTask ->
           genTask.group = "code-generation"
-          gen.source.takeIf { it.isPresent }?.let { genTask.source(gen.source) }
-          gen.includes.takeIf { it.isPresent }?.let { genTask.includes.set(it) }
+          genTask.source(gen.source)
+          genTask.includes.set(gen.includes)
           gen.framework.takeIf { it.isPresent }?.let { genTask.framework.set(it) }
           gen.mode.takeIf { it.isPresent }?.let { genTask.mode.set(it) }
           gen.generateModel.takeIf { it.isPresent }?.let { genTask.generateModel.set(it) }
@@ -65,6 +67,7 @@ class SundayGeneratorPlugin : Plugin<Project> {
           gen.baseUriMode.takeIf { it.isPresent }?.let { genTask.baseUriMode.set(it) }
           gen.defaultMediaTypes.takeIf { it.isPresent }?.let { genTask.defaultMediaTypes.set(it) }
           gen.generatedAnnotation.takeIf { it.isPresent }?.let { genTask.generatedAnnotation.set(it) }
+          gen.generationTimestamp.takeIf { it.isPresent }?.let { genTask.generationTimestamp.set(it) }
           gen.alwaysUseResponseReturn.takeIf { it.isPresent }?.let { genTask.alwaysUseResponseReturn.set(it) }
           gen.useResultResponseReturn.takeIf { it.isPresent }?.let { genTask.useResultResponseReturn.set(it) }
           gen.useJakartaPackages.takeIf { it.isPresent }?.let { genTask.useJakartaPackages.set(it) }
@@ -73,19 +76,9 @@ class SundayGeneratorPlugin : Plugin<Project> {
         }
 
       allTask.configure { it.dependsOn(genTask) }
-    }
 
-    project.afterEvaluate {
-
-      generationsContainer.all { gen ->
-
-        val genTask = project.tasks.named("sundayGenerate_${gen.name}", SundayGenerate::class.java)
-
-        val sourceSetName = gen.targetSourceSet.get()
-
-        val sourceSets = project.extensions.getByName("sourceSets") as SourceSetContainer
-        sourceSets.getByName(sourceSetName).java.srcDir(genTask)
-      }
+      val sourceSetName = gen.targetSourceSet.get()
+      sourceSets.getByName(sourceSetName).java.srcDir(genTask)
     }
   }
 }

--- a/gradle-plugin/src/main/kotlin/io/outfoxx/sunday/generator/gradle/SundayGeneratorPlugin.kt
+++ b/gradle-plugin/src/main/kotlin/io/outfoxx/sunday/generator/gradle/SundayGeneratorPlugin.kt
@@ -65,9 +65,8 @@ class SundayGeneratorPlugin : Plugin<Project> {
         project.tasks.register("sundayDiscoverIncludes_${gen.name}", SundayDiscoverIncludes::class.java) { task ->
           task.group = "code-generation"
           task.source(gen.source)
-          gen.includes.takeIf { it.isPresent }?.let { task.extraIncludes.set(it) }
           task.includesIndexFile.set(includesIndex)
-          task.bootstrapIncludes.from(discoveredIncludes)
+          task.bootstrapIncludes.set(discoveredIncludes)
         }
 
       val genTask =

--- a/gradle-plugin/src/test/kotlin/io/outfoxx/sunday/generator/gradle/tests/GradlePluginTests.kt
+++ b/gradle-plugin/src/test/kotlin/io/outfoxx/sunday/generator/gradle/tests/GradlePluginTests.kt
@@ -525,10 +525,8 @@ class GradlePluginTests {
     assertThat(discoverTask?.outcome, equalTo(TaskOutcome.SUCCESS))
   }
 
-
   @Test
   fun `disable container element validation applies use-site constraints`() {
-
     copy("/dualtest.kt", testProjectDir.resolve("src/main/kotlin"))
     copy("/validation-constraints.raml", testProjectDir.resolve("src/main/sunday"))
 

--- a/gradle-plugin/src/test/kotlin/io/outfoxx/sunday/generator/gradle/tests/GradlePluginTests.kt
+++ b/gradle-plugin/src/test/kotlin/io/outfoxx/sunday/generator/gradle/tests/GradlePluginTests.kt
@@ -18,10 +18,13 @@ package io.outfoxx.sunday.generator.gradle.tests
 
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.TaskOutcome
+import org.gradle.testkit.runner.UnexpectedBuildFailure
+import org.hamcrest.CoreMatchers.anyOf
 import org.hamcrest.CoreMatchers.containsString
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.CoreMatchers.not
 import org.hamcrest.MatcherAssert.assertThat
+import org.junit.jupiter.api.Assumptions.assumeTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
@@ -52,6 +55,80 @@ class GradlePluginTests {
       client {
         source.set(fileTree('src/main/sunday') { it.include('**/*.raml') })
         includes.set(fileTree('src/main/sunday-includes') { it.include('**/*.raml') })
+        framework.set(Sunday)
+        mode.set(Client)
+        pkgName.set('io.outfoxx.test.client')
+        modelPkgName.set('io.outfoxx.test.client.model')
+        servicePkgName.set('io.outfoxx.test.client.api')
+        generateModel.set(true)
+        generateService.set(true)
+        serviceSuffix.set('API')
+        disableValidationConstraints.set(false)
+        disableJacksonAnnotations.set(false)
+        disableModelImplementations.set(false)
+        coroutines.set(false)
+        reactiveResponseType.set(null)
+        explicitSecurityParameters.set(false)
+        baseUriMode.set(null)
+        defaultMediaTypes.set(["application/json"])
+        generatedAnnotation.set('javax.annotation.processing.Generated')
+        alwaysUseResponseReturn.set(false)
+        useResultResponseReturn.set(false)
+        useJakartaPackages.set(false)
+      }
+      server {
+        framework.set(JAXRS)
+        mode.set(Server)
+        reactiveResponseType.set("${CompletableFuture::class.java.canonicalName}")
+        pkgName.set('io.outfoxx.test.server')
+      }
+    }
+
+    dependencies {
+      implementation "io.outfoxx.sunday:sunday-core:1.0.0-beta.25"
+      implementation "org.jboss.spec.javax.ws.rs:jboss-jaxrs-api_2.0_spec:1.0.0.Final"
+      implementation "javax.validation:validation-api:2.0.1.Final"
+      implementation "com.fasterxml.jackson.core:jackson-databind:2.10.0"
+    }
+
+    java {
+      sourceCompatibility = "21"
+      targetCompatibility = "21"
+    }
+
+    compileKotlin {
+      kotlinOptions {
+        jvmTarget = "21"
+        suppressWarnings = true
+      }
+    }
+
+    if (hasProperty('buildScan')) {
+        buildScan {
+            termsOfServiceUrl = 'https://gradle.com/terms-of-service'
+            termsOfServiceAgree = 'yes'
+        }
+    }
+
+    """.trimIndent()
+
+  val dualTestBuildFileNoIncludes =
+    """
+    import static io.outfoxx.sunday.generator.gradle.TargetFramework.*
+    import static io.outfoxx.sunday.generator.GenerationMode.*
+
+    plugins {
+      id 'org.jetbrains.kotlin.jvm' version '2.3.10'
+      id 'io.outfoxx.sunday-generator'
+    }
+
+    repositories {
+      mavenCentral()
+    }
+
+    sundayGenerations {
+      client {
+        source.set(fileTree('src/main/sunday') { it.include('**/*.raml') })
         framework.set(Sunday)
         mode.set(Client)
         pkgName.set('io.outfoxx.test.client')
@@ -197,6 +274,62 @@ class GradlePluginTests {
   }
 
   @Test
+  fun `configuration cache is reused with build cache`() {
+
+    copy("/dualtest.kt", testProjectDir.resolve("src/main/kotlin"))
+
+    buildFile.writeText(dualTestBuildFile)
+
+    // Generate settings.gradle.kts with temporary build cache dir
+    testProjectDir.resolve("settings.gradle.kts").writeText(
+      """
+      buildCache {
+        local {
+          directory = file("${testProjectDir.resolve("local-cache")}")
+        }
+      }
+      """.trimIndent(),
+    )
+
+    val first =
+      try {
+        GradleRunner
+          .create()
+          .withProjectDir(testProjectDir)
+          .withPluginClasspath()
+          .withArguments("sundayGenerate_client", "--stacktrace", "--configuration-cache", "--build-cache")
+          .withDebug(true)
+          .build()
+      } catch (ex: UnexpectedBuildFailure) {
+        if (ex.message?.contains("support for using a Java agent with TestKit builds") == true) {
+          assumeTrue(false, "Gradle TestKit does not support configuration cache with Java agents yet.")
+        }
+        throw ex
+      }
+
+    assertThat(first.output, not(containsString("Configuration cache problems found")))
+
+    val second =
+      try {
+        GradleRunner
+          .create()
+          .withProjectDir(testProjectDir)
+          .withPluginClasspath()
+          .withArguments("sundayGenerate_client", "--stacktrace", "--configuration-cache", "--build-cache")
+          .withDebug(true)
+          .build()
+      } catch (ex: UnexpectedBuildFailure) {
+        if (ex.message?.contains("support for using a Java agent with TestKit builds") == true) {
+          assumeTrue(false, "Gradle TestKit does not support configuration cache with Java agents yet.")
+        }
+        throw ex
+      }
+
+    assertThat(second.output, containsString("Reusing configuration cache"))
+    assertThat(second.output, not(containsString("Configuration cache problems found")))
+  }
+
+  @Test
   fun `generate sources for kotlin are regenerated when sources changes`() {
 
     copy("/dualtest.kt", testProjectDir.resolve("src/main/kotlin"))
@@ -240,7 +373,10 @@ class GradlePluginTests {
       assertThat(genServerTask?.outcome, equalTo(outcome))
 
       val kotlinTask = result.task(":compileKotlin")
-      assertThat(kotlinTask?.outcome, equalTo(outcome))
+      assertThat(
+        kotlinTask?.outcome,
+        anyOf(equalTo(outcome), equalTo(TaskOutcome.FROM_CACHE), equalTo(TaskOutcome.UP_TO_DATE)),
+      )
     }
   }
 
@@ -282,17 +418,16 @@ class GradlePluginTests {
     )
 
     listOf(
-      TaskOutcome.SUCCESS to TaskOutcome.SUCCESS,
-      TaskOutcome.FROM_CACHE to TaskOutcome.FROM_CACHE,
-      TaskOutcome.SUCCESS to TaskOutcome.FROM_CACHE,
-    ).forEach { outcome ->
-      val (clientOutcome, serverOutcome) = outcome
+      Triple(TaskOutcome.SUCCESS, TaskOutcome.SUCCESS, false),
+      Triple(TaskOutcome.FROM_CACHE, TaskOutcome.FROM_CACHE, false),
+      Triple(TaskOutcome.SUCCESS, TaskOutcome.SUCCESS, true),
+    ).forEach { (clientOutcome, serverOutcome, updateInclude) ->
       println("Executing build expecting outcomes: client=$clientOutcome, server=$serverOutcome")
 
       // Delete build directory to test loading from cache
       testProjectDir.resolve("build").deleteRecursively()
 
-      if (outcome == TaskOutcome.SUCCESS to TaskOutcome.FROM_CACHE) {
+      if (updateInclude) {
         // Change contents of include.raml to force regeneration
         include.writeText(
           """
@@ -328,8 +463,88 @@ class GradlePluginTests {
       assertThat(genServerTask?.outcome, equalTo(serverOutcome))
 
       val kotlinTask = result.task(":compileKotlin")
-      assertThat(kotlinTask?.outcome, equalTo(clientOutcome))
+      assertThat(
+        kotlinTask?.outcome,
+        anyOf(equalTo(clientOutcome), equalTo(TaskOutcome.FROM_CACHE), equalTo(TaskOutcome.UP_TO_DATE)),
+      )
     }
+  }
+
+  @Test
+  fun `generate sources for kotlin are regenerated when default includes changes`() {
+
+    copy("/dualtest.kt", testProjectDir.resolve("src/main/kotlin"))
+
+    val includes = testProjectDir.resolve("src/main/sunday-includes")
+    includes.mkdirs()
+
+    val include = includes.resolve("include.raml")
+    include.writeText(
+      """
+      #%RAML 1.0
+      title: Test
+      version: 1.0.0
+      baseUri: http://localhost:8080/api
+      mediaType: application/json
+      types:
+        Test:
+          type: object
+          properties:
+            id: string
+      """.trimIndent(),
+    )
+
+    buildFile.writeText(dualTestBuildFileNoIncludes)
+
+    // Generate settings.gradle.kts with temporary build cache dir
+    testProjectDir.resolve("settings.gradle.kts").writeText(
+      """
+      buildCache {
+        local {
+          directory = file("${testProjectDir.resolve("local-cache")}")
+        }
+      }
+      """.trimIndent(),
+    )
+
+    GradleRunner
+      .create()
+      .withProjectDir(testProjectDir)
+      .withPluginClasspath()
+      .withArguments("build", "--stacktrace", "--debug", "--build-cache")
+      .withDebug(true)
+      .build()
+
+    include.writeText(
+      """
+      #%RAML 1.0
+      title: Test
+      version: 1.0.0
+      baseUri: http://localhost:8080/api
+      mediaType: application/json
+      types:
+        Test:
+          type: object
+          properties:
+            id: string
+            name: string
+      """.trimIndent(),
+    )
+
+    val result =
+      GradleRunner
+        .create()
+        .withProjectDir(testProjectDir)
+        .withPluginClasspath()
+        .withArguments("build", "--stacktrace", "--debug", "--build-cache")
+        .withDebug(true)
+        .build()
+
+    val genClientTask = result.task(":sundayGenerate_client")
+    assertThat(genClientTask?.outcome, equalTo(TaskOutcome.SUCCESS))
+
+    val genServerTask = result.task(":sundayGenerate_server")
+    assertThat(genServerTask?.outcome, equalTo(TaskOutcome.SUCCESS))
   }
 
   @Test


### PR DESCRIPTION
## Summary
- make Sunday Gradle tasks configuration-cache safe (remove afterEvaluate and project access at execution)
- ensure cacheable task inputs/outputs are explicit and deterministic (generation timestamps now optional)
- add include discovery task with bootstrap index to track nested includes without manual config
- deprecate `includes` DSL and make it a no-op (auto-discovery instead)
- skip RAML fragments during include discovery to avoid AMF parsing errors

## Testing
- `./gradlew :gradle-plugin:test` (config-cache TestKit case skipped due to Gradle limitation)
