### PR TITLE
Map OpenAPI empty schemas to any IR type

### DIFF
--- a/generator/src/main/kotlin/io/outfoxx/sunday/generator/ir/OpenApiToGeneratedApi.kt
+++ b/generator/src/main/kotlin/io/outfoxx/sunday/generator/ir/OpenApiToGeneratedApi.kt
@@ -272,8 +272,12 @@ class OpenApiToGeneratedApi(
       )
     }
 
-    val type = schema.schemaType()
     val nullable = schema.isNullable()
+    if (schema.isUnconstrainedSchema()) {
+      return scalar("any", nullable = nullable)
+    }
+
+    val type = schema.schemaType()
     return when (type) {
       "array" ->
         GeneratedTypeRef(
@@ -354,6 +358,17 @@ class OpenApiToGeneratedApi(
           scope = scope,
           values = resolved.listValue("enum").mapNotNull { it?.toString() },
           documentation = documentation(description = resolved["description"] as? String),
+        )
+
+      resolved.isUnconstrainedSchema() ->
+        GeneratedModel(
+          name = name,
+          kind = GeneratedModel.Kind.SCALAR_ALIAS,
+          scope = scope,
+          aliases = listOf(scalar("any", nullable = resolved.isNullable())),
+          documentation = documentation(description = resolved["description"] as? String),
+          examples = resolved.examples(),
+          deprecated = resolved["deprecated"] == true,
         )
 
       resolved.schemaType() == "array" ->
@@ -888,6 +903,11 @@ class OpenApiToGeneratedApi(
         }
     }
 
+  private fun Map<*, *>.isUnconstrainedSchema(): Boolean =
+    keys.all { key ->
+      key is String && (key in unconstrainedSchemaKeys || key.startsWith("x-"))
+    }
+
   private fun Map<*, *>.isNullable(): Boolean =
     this["nullable"] == true || (this["type"] as? List<*>)?.contains("null") == true
 
@@ -1037,6 +1057,27 @@ class OpenApiToGeneratedApi(
   private companion object {
 
     val httpMethods = setOf("get", "put", "post", "delete", "options", "head", "patch", "trace")
+    val unconstrainedSchemaKeys =
+      setOf(
+        "\$anchor",
+        "\$comment",
+        "\$defs",
+        "\$dynamicAnchor",
+        "\$id",
+        "\$schema",
+        "default",
+        "definitions",
+        "deprecated",
+        "description",
+        "example",
+        "examples",
+        "externalDocs",
+        "nullable",
+        "readOnly",
+        "title",
+        "writeOnly",
+        "xml",
+      )
     val yamlMapper = ObjectMapper(YAMLFactory())
     var activeDocument: OpenApiSourceDocument? = null
   }

--- a/generator/src/test/kotlin/io/outfoxx/sunday/generator/ir/OpenApiToGeneratedApiTest.kt
+++ b/generator/src/test/kotlin/io/outfoxx/sunday/generator/ir/OpenApiToGeneratedApiTest.kt
@@ -202,6 +202,38 @@ class OpenApiToGeneratedApiTest {
   }
 
   @Test
+  fun `maps OpenAPI empty schemas to any JSON values`(
+    @ResourceUri("openapi/ir/any-json-3.1.yaml") testUri: URI,
+  ) {
+    val api = OpenApiToGeneratedApi().convert(testUri)
+    val operation =
+      api
+        .services
+        .single()
+        .operations
+        .single()
+    val anyJson = api.models.single { model -> model.name == "AnyJson" }
+    val anyHolder = api.models.single { model -> model.name == "AnyHolder" }
+
+    assertEquals(GeneratedTypeRef.scalar("any"), operation.requestBody?.type)
+    assertEquals(GeneratedTypeRef.named("AnyJson"), operation.responses.single().type)
+    assertEquals(GeneratedModel.Kind.SCALAR_ALIAS, anyJson.kind)
+    assertEquals(listOf(GeneratedTypeRef.scalar("any")), anyJson.aliases)
+    assertEquals(
+      GeneratedTypeRef.scalar("any"),
+      anyHolder.properties.single { property -> property.name == "value" }.type,
+    )
+    assertEquals(
+      GeneratedTypeRef.scalar("any"),
+      anyHolder.properties.single { property -> property.name == "documented" }.type,
+    )
+    assertEquals(
+      GeneratedTypeRef.named("AnyJson"),
+      anyHolder.properties.single { property -> property.name == "named" }.type,
+    )
+  }
+
+  @Test
   fun `maps OpenAPI 3_1 composition and discriminators to generated API IR`(
     @ResourceUri("openapi/ir/composition-3.1.yaml") testUri: URI,
   ) {

--- a/generator/src/test/kotlin/io/outfoxx/sunday/generator/kotlin/jaxrs/KotlinJAXRSIrGeneratorTest.kt
+++ b/generator/src/test/kotlin/io/outfoxx/sunday/generator/kotlin/jaxrs/KotlinJAXRSIrGeneratorTest.kt
@@ -23,6 +23,7 @@ import io.outfoxx.sunday.generator.GenerationMode
 import io.outfoxx.sunday.generator.ir.AsyncApiToGeneratedApi
 import io.outfoxx.sunday.generator.ir.GeneratedAdditionalProperties
 import io.outfoxx.sunday.generator.ir.GeneratedApi
+import io.outfoxx.sunday.generator.ir.GeneratedApiIrExporter
 import io.outfoxx.sunday.generator.ir.GeneratedModel
 import io.outfoxx.sunday.generator.ir.GeneratedModelProperty
 import io.outfoxx.sunday.generator.ir.GeneratedOperation
@@ -881,6 +882,29 @@ class KotlinJAXRSIrGeneratorTest {
     assertTrue(aggregateSource.contains("@RegisterRestClient(baseUri = \"http://localhost:9080\")"), aggregateSource)
     assertFalse(aggregateSource.contains("@Path(value = \"http://localhost:9080\")"), aggregateSource)
     assertFalse(usersSource.contains("@RegisterRestClient"), usersSource)
+  }
+
+  @OptIn(ExperimentalCompilerApi::class)
+  @Test
+  fun `treats OpenAPI empty schemas as Any in Kotlin JAX-RS`(
+    @ResourceUri("openapi/ir/any-json-3.1.yaml") testUri: URI,
+  ) {
+    val typeRegistry = clientTypeRegistry()
+    val api = GeneratedApiIrExporter().export(testUri)
+
+    KotlinJAXRSIrGenerator(api, typeRegistry, kotlinJAXRSTestOptions)
+      .generateServiceTypes()
+
+    val builtTypes = typeRegistry.buildTypes()
+    val holderSource = kotlinSource("io.test", findType("io.test.AnyHolder", builtTypes))
+    val serviceSource = kotlinSource("io.test.service", findType("io.test.service.API", builtTypes))
+
+    assertEquals(KotlinCompilation.ExitCode.OK, compileTypes(builtTypes))
+    assertTrue(holderSource.contains("public val `value`: Any?"), holderSource)
+    assertTrue(holderSource.contains("public val `documented`: Any?"), holderSource)
+    assertTrue(holderSource.contains("public val `named`: Any?"), holderSource)
+    assertTrue(serviceSource.contains("body: Any"), serviceSource)
+    assertTrue(serviceSource.contains("public fun updateValue("), serviceSource)
   }
 
   @OptIn(ExperimentalCompilerApi::class)

--- a/generator/src/test/kotlin/io/outfoxx/sunday/generator/kotlin/sunday/KotlinSundayIrGeneratorTest.kt
+++ b/generator/src/test/kotlin/io/outfoxx/sunday/generator/kotlin/sunday/KotlinSundayIrGeneratorTest.kt
@@ -1159,6 +1159,39 @@ class KotlinSundayIrGeneratorTest {
 
   @OptIn(ExperimentalCompilerApi::class)
   @Test
+  fun `treats OpenAPI empty schemas as Any in Kotlin Sunday`(
+    @ResourceUri("openapi/ir/any-json-3.1.yaml") testUri: URI,
+  ) {
+    val typeRegistry = typeRegistry()
+    val api = GeneratedApiIrExporter().export(testUri)
+
+    KotlinSundayIrGenerator(api, typeRegistry, kotlinSundayTestOptions)
+      .generateServiceTypes()
+
+    val builtTypes = typeRegistry.buildTypes()
+    val holderSource =
+      buildString {
+        FileSpec
+          .get("io.test", findType("io.test.AnyHolder", builtTypes))
+          .writeTo(this)
+      }
+    val serviceSource =
+      buildString {
+        FileSpec
+          .get("io.test.service", findType("io.test.service.API", builtTypes))
+          .writeTo(this)
+      }
+
+    assertEquals(KotlinCompilation.ExitCode.OK, compileTypes(builtTypes))
+    assertContains(holderSource, "public val `value`: Any?")
+    assertContains(holderSource, "public val `documented`: Any?")
+    assertContains(holderSource, "public val `named`: Any?")
+    assertContains(serviceSource, "body: Any")
+    assertContains(serviceSource, "Operation<Any, Any, Req>")
+  }
+
+  @OptIn(ExperimentalCompilerApi::class)
+  @Test
   fun `lowers supported IR scalar formats to Kotlin temporal and identity types`() {
     val typeRegistry = typeRegistry()
     val api =

--- a/generator/src/test/kotlin/io/outfoxx/sunday/generator/python/PythonGeneratedOutputParityTest.kt
+++ b/generator/src/test/kotlin/io/outfoxx/sunday/generator/python/PythonGeneratedOutputParityTest.kt
@@ -79,6 +79,32 @@ class PythonGeneratedOutputParityTest : PythonTest() {
   }
 
   @Test
+  fun `OpenAPI empty schemas emit object typed Python models and clients`(
+    compiler: PythonCompiler,
+    @ResourceUri("openapi/ir/any-json-3.1.yaml") sourceUri: URI,
+  ) {
+    val api = GeneratedApiIrExporter().export(sourceUri)
+    val modules = api.httpxModules()
+
+    assertTrue(
+      compileModules(
+        compiler,
+        modules,
+        importModules = modules.importModuleNames(),
+      ),
+    )
+    val modelSource = CompiledGeneratedSources.source(GeneratedCodeLanguage.Python, "parity_api/models.py")
+    val clientSource = CompiledGeneratedSources.source(GeneratedCodeLanguage.Python, "parity_api/any_json.py")
+
+    assertTrue(modelSource.contains("AnyJson = object"), modelSource)
+    assertTrue(modelSource.contains("value: object | None = None"), modelSource)
+    assertTrue(modelSource.contains("documented: object | None = None"), modelSource)
+    assertTrue(modelSource.contains("named: AnyJson | None = None"), modelSource)
+    assertTrue(clientSource.contains("body: object"), clientSource)
+    assertTrue(clientSource.contains("Operation[AnyJson]"), clientSource)
+  }
+
+  @Test
   fun `AsyncAPI source emits compile-backed client and server snapshots`(
     compiler: PythonCompiler,
     @ResourceUri("asyncapi/ir/typed-event-envelope-3.1.yaml") sourceUri: URI,

--- a/generator/src/test/kotlin/io/outfoxx/sunday/generator/swift/sunday/SwiftSundayIrGeneratorTest.kt
+++ b/generator/src/test/kotlin/io/outfoxx/sunday/generator/swift/sunday/SwiftSundayIrGeneratorTest.kt
@@ -190,6 +190,24 @@ class SwiftSundayIrGeneratorTest {
   }
 
   @Test
+  fun `Swift Sunday generated files treat OpenAPI empty schemas as AnyValue`(
+    compiler: SwiftCompiler,
+    @ResourceUri("openapi/ir/any-json-3.1.yaml") testUri: URI,
+  ) {
+    generateSwiftSundayFiles(compiler, GeneratedApiIrExporter().export(testUri))
+
+    val holderSource = Files.readString(compiler.srcDir.resolve("Models").resolve("AnyHolder.swift"))
+    val serviceSource = Files.readString(compiler.srcDir.resolve("API.swift"))
+
+    assertTrue(compileGeneratedFiles(compiler))
+    assertTrue(holderSource.contains("public let value: AnyValue?"), holderSource)
+    assertTrue(holderSource.contains("public let documented: AnyValue?"), holderSource)
+    assertTrue(holderSource.contains("public let named: AnyValue?"), holderSource)
+    assertTrue(serviceSource.contains("body: AnyValue"), serviceSource)
+    assertTrue(serviceSource.contains("Operation<AnyValue, AnyValue, TransportType>"), serviceSource)
+  }
+
+  @Test
   fun `Swift Sunday generated files compile from AsyncAPI source`(
     compiler: SwiftCompiler,
     @ResourceUri("asyncapi/ir/typed-event-envelope-3.1.yaml") testUri: URI,

--- a/generator/src/test/kotlin/io/outfoxx/sunday/generator/typescript/sunday/TypeScriptSundayIrGeneratorTest.kt
+++ b/generator/src/test/kotlin/io/outfoxx/sunday/generator/typescript/sunday/TypeScriptSundayIrGeneratorTest.kt
@@ -45,6 +45,7 @@ import io.outfoxx.sunday.test.extensions.ResourceUri
 import io.outfoxx.typescriptpoet.CodeBlock
 import io.outfoxx.typescriptpoet.FileSpec
 import io.outfoxx.typescriptpoet.ModuleSpec
+import io.outfoxx.typescriptpoet.SymbolSpec
 import io.outfoxx.typescriptpoet.TypeName
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -535,6 +536,44 @@ class TypeScriptSundayIrGeneratorTest {
     assertTrue(compileTypes(compiler, builtTypes))
     assertTrue(updateSource.contains("'location': z.string().regex(/^[A-Z2-7]{26}$/).nullish()"), updateSource)
     assertFalse(updateSource.contains("z.record(z.string(), z.unknown()).regex"), updateSource)
+  }
+
+  @Test
+  fun `treats OpenAPI empty schemas as unknown in TypeScript Sunday`(
+    compiler: TypeScriptCompiler,
+    @ResourceUri("openapi/ir/any-json-3.1.yaml") testUri: URI,
+  ) {
+    val typeRegistry = TypeScriptTypeRegistry(setOf())
+    val api = OpenApiToGeneratedApi().convert(testUri)
+
+    TypeScriptSundayIrGenerator(api, typeRegistry, typeScriptSundayTestOptions)
+      .generateServiceTypes()
+
+    val builtTypes = typeRegistry.buildTypes()
+    val holderSource =
+      buildString {
+        FileSpec
+          .get(findTypeMod("AnyHolder@!any-holder", builtTypes), "any-holder")
+          .writeTo(this)
+      }
+    val serviceSource =
+      builtTypes
+        .map { (typeName, moduleSpec) ->
+          val imported = typeName.base as SymbolSpec.Imported
+          val modulePath = imported.source.removePrefix("!")
+          buildString {
+            FileSpec
+              .get(moduleSpec, modulePath)
+              .writeTo(this)
+          }
+        }.single { source -> source.contains("updateValue") }
+
+    assertTrue(compileTypes(compiler, builtTypes))
+    assertTrue(holderSource.contains("'value': z.unknown().nullish()"), holderSource)
+    assertTrue(holderSource.contains("'documented': z.unknown().nullish()"), holderSource)
+    assertTrue(holderSource.contains("'named': z.unknown().nullish()"), holderSource)
+    assertTrue(serviceSource.contains("body: unknown"), serviceSource)
+    assertTrue(serviceSource.contains("Operation<unknown, unknown, Factory>"), serviceSource)
   }
 
   @Test

--- a/generator/src/test/resources/openapi/ir/any-json-3.1.yaml
+++ b/generator/src/test/resources/openapi/ir/any-json-3.1.yaml
@@ -1,0 +1,30 @@
+openapi: 3.1.0
+info:
+  title: Any JSON API
+  version: 1.0.0
+paths:
+  /values:
+    post:
+      operationId: updateValue
+      requestBody:
+        content:
+          application/json:
+            schema: {}
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AnyJson'
+components:
+  schemas:
+    AnyJson: {}
+    AnyHolder:
+      type: object
+      properties:
+        value: {}
+        documented:
+          description: Any documented value
+        named:
+          $ref: '#/components/schemas/AnyJson'


### PR DESCRIPTION
Summary: map unconstrained OpenAPI schemas to IR scalar any instead of object/map; keep component empty schemas as scalar aliases to any; add compile-backed coverage for Swift, Kotlin, Kotlin/JAX-RS, TypeScript, and Python targets. Tests: ./gradlew :generator:test with OpenApiToGeneratedApiTest and focused target tests passed; ./gradlew :generator:ktlintCheck --rerun-tasks passed.