### PR TITLE
Keep Swift discriminator families in grouped output

### DIFF
--- a/generator/src/main/kotlin/io/outfoxx/sunday/generator/swift/SwiftSundayIrGenerator.kt
+++ b/generator/src/main/kotlin/io/outfoxx/sunday/generator/swift/SwiftSundayIrGenerator.kt
@@ -237,13 +237,18 @@ class SwiftSundayIrGenerator(
     api
       .models
       .filter { model -> model.scope == null }
-      .mapNotNull { model -> model.swiftTypeSpecBuilderOrNull()?.let { model to it } }
-      .forEach { (model, typeBuilder) ->
+      .mapNotNull { model ->
+        val outputDirectory = model.swiftOutputDirectory(model.swiftModelKey() in eventModelKeys)
+        val outputGroup = modelOutputGroups[model.swiftModelKey()]
+        model
+          .swiftTypeSpecBuilderOrNull(outputDirectory, outputGroup)
+          ?.let { typeBuilder -> Triple(model, outputDirectory, typeBuilder) }
+      }.forEach { (model, outputDirectory, typeBuilder) ->
         val typeName = model.swiftDeclaredTypeName()
         typeRegistry.addModelType(
           typeName,
           typeBuilder,
-          outputDirectory = model.swiftOutputDirectory(model.swiftModelKey() in eventModelKeys),
+          outputDirectory = outputDirectory,
           outputGroup = modelOutputGroups[model.swiftModelKey()],
         )
       }
@@ -273,17 +278,88 @@ class SwiftSundayIrGenerator(
 
   private fun List<GeneratedService>.modelOutputGroups(
     serviceOutputGroups: Map<GeneratedService, String>,
-  ): Map<SwiftModelKey, String> =
-    flatMap { service ->
-      service.operations.flatMap { operation ->
-        val outputGroup = serviceOutputGroups[service] ?: operation.swiftOutputGroup()
-        operation
-          .referencedTopLevelModels()
-          .mapNotNull { model -> outputGroup?.let { group -> model.swiftModelKey() to group } }
+  ): Map<SwiftModelKey, String> {
+    val referencedGroups =
+      flatMap { service ->
+        service.operations.flatMap { operation ->
+          val outputGroup = serviceOutputGroups[service] ?: operation.swiftOutputGroup()
+          operation
+            .referencedTopLevelModels()
+            .mapNotNull { model -> outputGroup?.let { group -> model.swiftModelKey() to group } }
+        }
       }
-    }.groupBy({ (modelKey) -> modelKey }, { (_, group) -> group })
-      .mapNotNull { (modelKey, groups) -> groups.distinct().singleOrNull()?.let { group -> modelKey to group } }
-      .toMap()
+    val directGroups =
+      referencedGroups
+        .groupBy({ (modelKey) -> modelKey }, { (_, group) -> group })
+        .mapNotNull { (modelKey, groups) -> groups.distinct().singleOrNull()?.let { group -> modelKey to group } }
+        .toMap()
+
+    return directGroups.withDiscriminatorFamilyGroups()
+  }
+
+  private fun Map<SwiftModelKey, String>.withDiscriminatorFamilyGroups(): Map<SwiftModelKey, String> {
+    val outputGroups = toMutableMap()
+    val modelKeys =
+      api
+        .models
+        .filter { model -> model.scope == null }
+        .associateBy { model -> model.swiftModelKey() }
+
+    var changed = true
+    while (changed) {
+      changed = false
+
+      api
+        .models
+        .filter { model -> model.scope == null }
+        .forEach { model ->
+          val familyKeys = model.discriminatorFamilyKeys(modelKeys)
+          val familyGroups = familyKeys.mapNotNull { modelKey -> outputGroups[modelKey] }.distinct()
+          if (familyGroups.size != 1) {
+            return@forEach
+          }
+
+          val familyGroup = familyGroups.single()
+          familyKeys.forEach { modelKey ->
+            if (modelKey !in outputGroups) {
+              outputGroups[modelKey] = familyGroup
+              changed = true
+            }
+          }
+        }
+    }
+
+    return outputGroups
+  }
+
+  private fun GeneratedModel.discriminatorFamilyKeys(
+    modelKeys: Map<SwiftModelKey, GeneratedModel>,
+  ): Set<SwiftModelKey> =
+    buildSet {
+      add(swiftModelKey())
+
+      inherits
+        .mapNotNull { type -> type.modelOrNull(apiIndex)?.takeIf { model -> model.scope == null } }
+        .forEach { model -> add(model.swiftModelKey()) }
+
+      discriminatorMappings
+        .values
+        .mapNotNull { type -> type.modelOrNull(apiIndex)?.takeIf { model -> model.scope == null } }
+        .forEach { model -> add(model.swiftModelKey()) }
+
+      discriminator
+        ?.let { discriminatorName -> properties.firstOrNull { property -> property.name == discriminatorName } }
+        ?.type
+        ?.modelOrNull(apiIndex)
+        ?.takeIf { model -> model.scope == null }
+        ?.let { model -> add(model.swiftModelKey()) }
+
+      val modelKey = swiftModelKey()
+      modelKeys
+        .values
+        .filter { model -> model.inherits.any { type -> type.modelOrNull(apiIndex)?.swiftModelKey() == modelKey } }
+        .forEach { model -> add(model.swiftModelKey()) }
+    }
 
   private fun List<GeneratedService>.problemOutputGroups(
     serviceOutputGroups: Map<GeneratedService, String>,
@@ -700,7 +776,10 @@ class SwiftSundayIrGenerator(
       .referencedScopedModels(this)
       .mapNotNull { model -> model.swiftTypeSpecBuilderOrNull()?.build() }
 
-  private fun GeneratedModel.swiftTypeSpecBuilderOrNull(): TypeSpec.Builder? =
+  private fun GeneratedModel.swiftTypeSpecBuilderOrNull(
+    outputDirectory: OutputDirectory = OutputDirectory.Models,
+    outputGroup: String? = null,
+  ): TypeSpec.Builder? =
     when (kind) {
       GeneratedModel.Kind.ENUM ->
         TypeSpec
@@ -719,7 +798,7 @@ class SwiftSundayIrGenerator(
           ?: when {
             isExternalDiscriminatorBaseProtocolModel -> swiftExternalDiscriminatorBaseProtocolTypeSpec()
             isExternalDiscriminatorCaseValueModel -> swiftExternalDiscriminatorCaseValueTypeSpec()
-            else -> swiftObjectTypeSpec()
+            else -> swiftObjectTypeSpec(outputDirectory, outputGroup)
           }
 
       GeneratedModel.Kind.UNION -> swiftUnionTypeSpecOrNull()
@@ -1499,7 +1578,10 @@ class SwiftSundayIrGenerator(
       }.build()
   }
 
-  private fun GeneratedModel.swiftObjectTypeSpec(): TypeSpec.Builder {
+  private fun GeneratedModel.swiftObjectTypeSpec(
+    outputDirectory: OutputDirectory = OutputDirectory.Models,
+    outputGroup: String? = null,
+  ): TypeSpec.Builder {
     val typeName = swiftDeclaredTypeName()
     val inheritedModel = inherits.firstOrNull()?.modelOrNull(apiIndex)
     val inheritedTypeName = inheritedModel?.swiftDeclaredTypeName()
@@ -1690,7 +1772,7 @@ class SwiftSundayIrGenerator(
         )
       }
     }
-    referenceTypeOrNull(typeName)?.let { referenceType ->
+    referenceTypeOrNull(typeName, outputDirectory, outputGroup)?.let { referenceType ->
       if (!isProtocolModel) {
         typeBuilder.addType(referenceType)
       }
@@ -2009,7 +2091,11 @@ class SwiftSundayIrGenerator(
       }.build()
   }
 
-  private fun GeneratedModel.referenceTypeOrNull(typeName: DeclaredTypeName): TypeSpec? {
+  private fun GeneratedModel.referenceTypeOrNull(
+    typeName: DeclaredTypeName,
+    outputDirectory: OutputDirectory,
+    outputGroup: String?,
+  ): TypeSpec? {
     if (discriminator == null || externallyDiscriminated || inherits.isNotEmpty()) {
       return null
     }
@@ -2148,7 +2234,12 @@ class SwiftSundayIrGenerator(
         }
 
     if (isProtocolHierarchyRootModel || isProblemHierarchyProtocolModel) {
-      typeRegistry.addModelType(anyRefTypeName, referenceType)
+      typeRegistry.addModelType(
+        anyRefTypeName,
+        referenceType,
+        outputDirectory = outputDirectory,
+        outputGroup = outputGroup,
+      )
       return null
     }
 

--- a/generator/src/main/kotlin/io/outfoxx/sunday/generator/swift/SwiftSundayIrGenerator.kt
+++ b/generator/src/main/kotlin/io/outfoxx/sunday/generator/swift/SwiftSundayIrGenerator.kt
@@ -242,14 +242,15 @@ class SwiftSundayIrGenerator(
         val outputGroup = modelOutputGroups[model.swiftModelKey()]
         model
           .swiftTypeSpecBuilderOrNull(outputDirectory, outputGroup)
-          ?.let { typeBuilder -> Triple(model, outputDirectory, typeBuilder) }
-      }.forEach { (model, outputDirectory, typeBuilder) ->
+          ?.let { typeBuilder -> GeneratedSwiftModel(model, outputDirectory, outputGroup, typeBuilder) }
+      }.forEach { generatedModel ->
+        val (model, outputDirectory, outputGroup, typeBuilder) = generatedModel
         val typeName = model.swiftDeclaredTypeName()
         typeRegistry.addModelType(
           typeName,
           typeBuilder,
           outputDirectory = outputDirectory,
-          outputGroup = modelOutputGroups[model.swiftModelKey()],
+          outputGroup = outputGroup,
         )
       }
   }
@@ -316,6 +317,7 @@ class SwiftSundayIrGenerator(
           val familyKeys = model.discriminatorFamilyKeys(modelKeys)
           val familyGroups = familyKeys.mapNotNull { modelKey -> outputGroups[modelKey] }.distinct()
           if (familyGroups.size != 1) {
+            // Ambiguous shared families stay ungrouped unless every grouped reference agrees on the same group.
             return@forEach
           }
 
@@ -477,6 +479,13 @@ class SwiftSundayIrGenerator(
   private data class GeneratedSwiftService(
     val service: GeneratedService,
     val typeName: DeclaredTypeName,
+  )
+
+  private data class GeneratedSwiftModel(
+    val model: GeneratedModel,
+    val outputDirectory: OutputDirectory,
+    val outputGroup: String?,
+    val typeBuilder: TypeSpec.Builder,
   )
 
   private data class UnionPropertyBranch(

--- a/generator/src/test/kotlin/io/outfoxx/sunday/generator/ir/OpenApiToGeneratedApiTest.kt
+++ b/generator/src/test/kotlin/io/outfoxx/sunday/generator/ir/OpenApiToGeneratedApiTest.kt
@@ -209,11 +209,11 @@ class OpenApiToGeneratedApiTest {
     val operation =
       api
         .services
-        .single()
-        .operations
-        .single()
+        .flatMap { service -> service.operations }
+        .single { operation -> operation.id == "updateValue" }
     val anyJson = api.models.single { model -> model.name == "AnyJson" }
     val anyHolder = api.models.single { model -> model.name == "AnyHolder" }
+    val entityStatePropertyValue = api.models.single { model -> model.name == "EntityStatePropertyValue" }
 
     assertEquals(GeneratedTypeRef.scalar("any"), operation.requestBody?.type)
     assertEquals(GeneratedTypeRef.named("AnyJson"), operation.responses.single().type)
@@ -230,6 +230,13 @@ class OpenApiToGeneratedApiTest {
     assertEquals(
       GeneratedTypeRef.named("AnyJson"),
       anyHolder.properties.single { property -> property.name == "named" }.type,
+    )
+    assertEquals(GeneratedModel.Kind.OBJECT, entityStatePropertyValue.kind)
+    assertEquals(listOf(GeneratedTypeRef.named("EntityStateProperty")), entityStatePropertyValue.inherits)
+    assertEquals("value", entityStatePropertyValue.discriminatorValue)
+    assertEquals(
+      GeneratedTypeRef.scalar("any"),
+      entityStatePropertyValue.properties.single { property -> property.name == "value" }.type,
     )
   }
 

--- a/generator/src/test/kotlin/io/outfoxx/sunday/generator/swift/sunday/SwiftSundayIrGeneratorTest.kt
+++ b/generator/src/test/kotlin/io/outfoxx/sunday/generator/swift/sunday/SwiftSundayIrGeneratorTest.kt
@@ -19,6 +19,7 @@ package io.outfoxx.sunday.generator.swift.sunday
 import io.outfoxx.sunday.generator.GeneratedTypeCategory
 import io.outfoxx.sunday.generator.ir.GeneratedApi
 import io.outfoxx.sunday.generator.ir.GeneratedApiIrExporter
+import io.outfoxx.sunday.generator.ir.GeneratedApiIrOptions
 import io.outfoxx.sunday.generator.ir.GeneratedCollectionKind
 import io.outfoxx.sunday.generator.ir.GeneratedDocumentation
 import io.outfoxx.sunday.generator.ir.GeneratedModel
@@ -194,15 +195,44 @@ class SwiftSundayIrGeneratorTest {
     compiler: SwiftCompiler,
     @ResourceUri("openapi/ir/any-json-3.1.yaml") testUri: URI,
   ) {
-    generateSwiftSundayFiles(compiler, GeneratedApiIrExporter().export(testUri))
+    generateSwiftSundayFiles(
+      compiler,
+      GeneratedApiIrExporter(GeneratedApiIrOptions(deriveServicesFromTags = true)).export(testUri),
+    )
 
     val holderSource = Files.readString(compiler.srcDir.resolve("Models").resolve("AnyHolder.swift"))
-    val serviceSource = Files.readString(compiler.srcDir.resolve("API.swift"))
+    val entityStatePropertyValueSource =
+      Files.readString(
+        compiler.srcDir
+          .resolve("Narrative")
+          .resolve("Models")
+          .resolve("EntityStatePropertyValue.swift"),
+      )
+    val entityStatePropertyRefSource =
+      Files.readString(
+        compiler.srcDir
+          .resolve("Narrative")
+          .resolve("Models")
+          .resolve("EntityStatePropertyRef.swift"),
+      )
+    val serviceSource = Files.readString(compiler.srcDir.resolve("NarrativeAPI.swift"))
 
     assertTrue(compileGeneratedFiles(compiler))
     assertTrue(holderSource.contains("public let value: AnyValue?"), holderSource)
     assertTrue(holderSource.contains("public let documented: AnyValue?"), holderSource)
     assertTrue(holderSource.contains("public let named: AnyValue?"), holderSource)
+    assertTrue(
+      entityStatePropertyValueSource.contains("public struct EntityStatePropertyValue : EntityStateProperty"),
+      entityStatePropertyValueSource,
+    )
+    assertTrue(
+      entityStatePropertyValueSource.contains("public let value: AnyValue?"),
+      entityStatePropertyValueSource,
+    )
+    assertTrue(
+      entityStatePropertyRefSource.contains("case value(EntityStatePropertyValue)"),
+      entityStatePropertyRefSource,
+    )
     assertTrue(serviceSource.contains("body: AnyValue"), serviceSource)
     assertTrue(serviceSource.contains("Operation<AnyValue, AnyValue, TransportType>"), serviceSource)
   }

--- a/generator/src/test/resources/openapi/ir/any-json-3.1.yaml
+++ b/generator/src/test/resources/openapi/ir/any-json-3.1.yaml
@@ -5,6 +5,8 @@ info:
 paths:
   /values:
     post:
+      tags:
+        - Narrative
       operationId: updateValue
       requestBody:
         content:
@@ -17,6 +19,23 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/AnyJson'
+  /properties:
+    put:
+      tags:
+        - Narrative
+      operationId: updateProperty
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EntityStatePropertyMap'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EntityStatePropertyMap'
 components:
   schemas:
     AnyJson: {}
@@ -28,3 +47,43 @@ components:
           description: Any documented value
         named:
           $ref: '#/components/schemas/AnyJson'
+    EntityStatePropertyType:
+      type: string
+      enum:
+        - value
+        - map
+    EntityStateProperty:
+      type: object
+      required:
+        - type
+      discriminator:
+        propertyName: type
+        mapping:
+          value: '#/components/schemas/EntityStatePropertyValue'
+          map: '#/components/schemas/EntityStatePropertyMap'
+      properties:
+        type:
+          $ref: '#/components/schemas/EntityStatePropertyType'
+    EntityStatePropertyValue:
+      allOf:
+        - $ref: '#/components/schemas/EntityStateProperty'
+        - type: object
+          required:
+            - enhancers
+          properties:
+            value: {}
+            enhancers:
+              type: array
+              items:
+                type: string
+    EntityStatePropertyMap:
+      allOf:
+        - $ref: '#/components/schemas/EntityStateProperty'
+        - type: object
+          required:
+            - properties
+          properties:
+            properties:
+              type: object
+              additionalProperties:
+                $ref: '#/components/schemas/EntityStateProperty'


### PR DESCRIPTION
## Summary

- Keep Swift/Sunday discriminator and inheritance model families in the same grouped output directory.
- Preserve OpenAPI empty-schema properties as any JSON values without losing discriminator cases.
- Extend the any-JSON fixture to cover an EntityStateProperty-style discriminator family.

## Root Cause

Swift grouped model placement was inferred from direct operation references, but the generated reference enum for protocol-style discriminator roots was registered without the root model output group. That allowed discriminator family files to split between root Models and grouped Models when services were derived from tags.

## Validation

- ./gradlew :generator:test --tests io.outfoxx.sunday.generator.ir.OpenApiToGeneratedApiTest --tests io.outfoxx.sunday.generator.swift.sunday.SwiftSundayIrGeneratorTest --rerun-tasks
- ./gradlew :generator:ktlintCheck --rerun-tasks
- ./gradlew :generator:test --tests io.outfoxx.sunday.generator.kotlin.sunday.KotlinSundayIrGeneratorTest --tests io.outfoxx.sunday.generator.kotlin.jaxrs.KotlinJAXRSIrGeneratorTest --tests io.outfoxx.sunday.generator.typescript.sunday.TypeScriptSundayIrGeneratorTest --tests io.outfoxx.sunday.generator.python.PythonGeneratedOutputParityTest --rerun-tasks
- TurnPost-style Swift generation verified EntityStateProperty* files land under Narrative/Models with EntityStatePropertyValue.value as AnyValue?.
