### PR TITLE
Add Quarkus REST client metadata generation

### DIFF
--- a/docs/sunday-ir-format.md
+++ b/docs/sunday-ir-format.md
@@ -27,7 +27,7 @@ This composition boundary lets OpenAPI and AsyncAPI describe different parts of 
 
 The AsyncAPI reader maps subscribe operations as event-stream responses on composed services and publish operations as request-only message sends. It currently covers API identity, service identity, operation identity, channel operations, JSON message payload media, object payload models, message headers, component schema refs, operation/message documentation, message examples, arrays, enums, maps, nullable unions, validation constraints, wire-name preservation, servers, security requirements, security schemes, and server/channel/operation bindings. Broader protocol-specific binding interpretation remains source-reader follow-up work.
 
-Composition keeps the first fragment's API-level metadata by default and fills missing metadata such as `auth`, `protocol`, `media`, targets, tags, and documentation from later fragments. When services merge by identity, service-level metadata such as `baseUri`, `auth`, `protocol`, `media`, and documentation is also preserved from the first fragment that provides it.
+Composition keeps the first fragment's API-level metadata by default and fills missing metadata such as `auth`, `jaxrs`, `protocol`, `media`, targets, tags, and documentation from later fragments. When services merge by identity, service-level metadata such as `baseUri`, `auth`, `jaxrs`, `protocol`, `media`, and documentation is also preserved from the first fragment that provides it.
 
 ## Top-Level Fields
 
@@ -93,7 +93,7 @@ Auth metadata preserves source scheme names in `schemes`, resolved security requ
 
 Operations may carry `policy` metadata for target-independent policy inputs. The OpenAPI reader maps `x-sunday-policy` into `timeout`, `retry`, `circuitBreaker`, `clientRateLimit`, `serverRateLimit`, and `source` fields. These fields remain source metadata until target emitters decide whether to generate runtime policy data, Quarkus Fault Tolerance annotations, or no output. Kotlin/JAX-RS Quarkus output lowers supported policy fields to SmallRye Fault Tolerance annotations.
 
-Operations may carry `jaxrs` metadata for Quarkus/JAX-RS parity. This includes `asynchronous`, `reactive`, mode-specific `sse` and `jsonBody` flags, and requested JAX-RS `context` parameters. This metadata is target-specific source metadata, not a recommendation that non-JAX-RS clients expose these concepts.
+APIs, services, tags, and operations may carry `jaxrs` metadata for Quarkus/JAX-RS parity. Operation metadata includes `asynchronous`, `reactive`, mode-specific `sse` and `jsonBody` flags, and requested JAX-RS `context` parameters. API, service, and tag metadata may include `restClient` metadata for Quarkus REST Client output: `configKey`, `oidcClient`, and `providers`. In aggregated JAX-RS client output, only API-level `restClient` metadata is lowered onto the registered aggregate client; tag/service metadata remains available for non-aggregated service client generation. This metadata is target-specific source metadata, not a recommendation that non-JAX-RS clients expose these concepts.
 
 ## Examples
 

--- a/generator/src/main/kotlin/io/outfoxx/sunday/generator/APIAnnotationName.kt
+++ b/generator/src/main/kotlin/io/outfoxx/sunday/generator/APIAnnotationName.kt
@@ -79,6 +79,7 @@ enum class APIAnnotationName(
   JsonBody("jsonBody", true),
 
   JaxrsContext("jaxrsContext", false),
+  JaxrsRestClient("jaxrsRestClient", false),
 
   ;
 

--- a/generator/src/main/kotlin/io/outfoxx/sunday/generator/ir/GeneratedApi.kt
+++ b/generator/src/main/kotlin/io/outfoxx/sunday/generator/ir/GeneratedApi.kt
@@ -27,6 +27,7 @@ data class GeneratedApi(
   val models: List<GeneratedModel> = listOf(),
   val problems: List<GeneratedProblem> = listOf(),
   val auth: GeneratedAuth? = null,
+  val jaxrs: GeneratedJaxrs? = null,
   val protocol: GeneratedProtocol? = null,
   val media: GeneratedMedia? = null,
   val targets: Map<String, GeneratedTarget> = mapOf(),

--- a/generator/src/main/kotlin/io/outfoxx/sunday/generator/ir/GeneratedApiComposer.kt
+++ b/generator/src/main/kotlin/io/outfoxx/sunday/generator/ir/GeneratedApiComposer.kt
@@ -72,6 +72,7 @@ class GeneratedApiComposer {
       models = models.values.map { it.model },
       problems = problems.values.map { it.problem },
       auth = fragments.firstNotNullOfOrNull { it.api.auth },
+      jaxrs = fragments.firstNotNullOfOrNull { it.api.jaxrs },
       protocol = fragments.firstNotNullOfOrNull { it.api.protocol },
       media = fragments.firstNotNullOfOrNull { it.api.media },
       targets = targets,

--- a/generator/src/main/kotlin/io/outfoxx/sunday/generator/ir/GeneratedApiComposer.kt
+++ b/generator/src/main/kotlin/io/outfoxx/sunday/generator/ir/GeneratedApiComposer.kt
@@ -237,6 +237,7 @@ class GeneratedApiComposer {
       baseUri = baseUri ?: other.baseUri,
       baseUriParameters = baseUriParameters.ifEmpty { other.baseUriParameters },
       auth = auth ?: other.auth,
+      jaxrs = jaxrs ?: other.jaxrs,
       protocol = protocol ?: other.protocol,
       media = media ?: other.media,
       documentation = documentation ?: other.documentation,

--- a/generator/src/main/kotlin/io/outfoxx/sunday/generator/ir/GeneratedJaxrs.kt
+++ b/generator/src/main/kotlin/io/outfoxx/sunday/generator/ir/GeneratedJaxrs.kt
@@ -25,4 +25,5 @@ data class GeneratedJaxrs(
   val sse: GeneratedModeFlag? = null,
   val jsonBody: GeneratedModeFlag? = null,
   val context: List<String> = listOf(),
+  val restClient: GeneratedJaxrsRestClient? = null,
 )

--- a/generator/src/main/kotlin/io/outfoxx/sunday/generator/ir/GeneratedJaxrsRestClient.kt
+++ b/generator/src/main/kotlin/io/outfoxx/sunday/generator/ir/GeneratedJaxrsRestClient.kt
@@ -17,17 +17,10 @@
 package io.outfoxx.sunday.generator.ir
 
 /**
- * Generated service declaration.
+ * Quarkus REST Client metadata for generated JAX-RS client interfaces.
  */
-data class GeneratedService(
-  val name: String,
-  val baseUri: String? = null,
-  val baseUriParameters: List<GeneratedParameter> = listOf(),
-  val group: String? = null,
-  val operations: List<GeneratedOperation> = listOf(),
-  val auth: GeneratedAuth? = null,
-  val jaxrs: GeneratedJaxrs? = null,
-  val protocol: GeneratedProtocol? = null,
-  val media: GeneratedMedia? = null,
-  val documentation: GeneratedDocumentation? = null,
+data class GeneratedJaxrsRestClient(
+  val configKey: String? = null,
+  val oidcClient: String? = null,
+  val providers: List<String> = listOf(),
 )

--- a/generator/src/main/kotlin/io/outfoxx/sunday/generator/ir/GeneratedJaxrsRestClient.kt
+++ b/generator/src/main/kotlin/io/outfoxx/sunday/generator/ir/GeneratedJaxrsRestClient.kt
@@ -33,7 +33,14 @@ internal fun GeneratedJaxrs?.mergeWith(other: GeneratedJaxrs?): GeneratedJaxrs? 
     return this
   }
   val restClient = restClient.mergeWith(other.restClient)
-  return copy(restClient = restClient).takeUnless { it == GeneratedJaxrs() }
+  return GeneratedJaxrs(
+    asynchronous = other.asynchronous ?: asynchronous,
+    reactive = other.reactive ?: reactive,
+    sse = other.sse ?: sse,
+    jsonBody = other.jsonBody ?: jsonBody,
+    context = (context + other.context).distinct(),
+    restClient = restClient,
+  ).takeUnless { it == GeneratedJaxrs() }
 }
 
 internal fun GeneratedJaxrsRestClient?.mergeWith(other: GeneratedJaxrsRestClient?): GeneratedJaxrsRestClient? {

--- a/generator/src/main/kotlin/io/outfoxx/sunday/generator/ir/GeneratedJaxrsRestClient.kt
+++ b/generator/src/main/kotlin/io/outfoxx/sunday/generator/ir/GeneratedJaxrsRestClient.kt
@@ -24,3 +24,28 @@ data class GeneratedJaxrsRestClient(
   val oidcClient: String? = null,
   val providers: List<String> = listOf(),
 )
+
+internal fun GeneratedJaxrs?.mergeWith(other: GeneratedJaxrs?): GeneratedJaxrs? {
+  if (this == null) {
+    return other
+  }
+  if (other == null) {
+    return this
+  }
+  val restClient = restClient.mergeWith(other.restClient)
+  return copy(restClient = restClient).takeUnless { it == GeneratedJaxrs() }
+}
+
+internal fun GeneratedJaxrsRestClient?.mergeWith(other: GeneratedJaxrsRestClient?): GeneratedJaxrsRestClient? {
+  if (this == null) {
+    return other
+  }
+  if (other == null) {
+    return this
+  }
+  return GeneratedJaxrsRestClient(
+    configKey = other.configKey ?: configKey,
+    oidcClient = other.oidcClient ?: oidcClient,
+    providers = (providers + other.providers).distinct(),
+  ).takeUnless { it == GeneratedJaxrsRestClient() }
+}

--- a/generator/src/main/kotlin/io/outfoxx/sunday/generator/ir/GeneratedTag.kt
+++ b/generator/src/main/kotlin/io/outfoxx/sunday/generator/ir/GeneratedTag.kt
@@ -21,5 +21,6 @@ package io.outfoxx.sunday.generator.ir
  */
 data class GeneratedTag(
   val name: String,
+  val jaxrs: GeneratedJaxrs? = null,
   val documentation: GeneratedDocumentation? = null,
 )

--- a/generator/src/main/kotlin/io/outfoxx/sunday/generator/ir/OpenApiToGeneratedApi.kt
+++ b/generator/src/main/kotlin/io/outfoxx/sunday/generator/ir/OpenApiToGeneratedApi.kt
@@ -60,6 +60,7 @@ class OpenApiToGeneratedApi(
           models = localModels.values.sortedBy { model -> model.name },
           problems = document.problems(),
           auth = auth,
+          jaxrs = document.jaxrs(),
           media = GeneratedMedia(),
           tags = document.tags(),
           documentation = documentation(description = document.info["description"] as? String),
@@ -94,6 +95,18 @@ class OpenApiToGeneratedApi(
           .takeIf { it.isNotEmpty() }
           ?.let {
             val serviceName = serviceName(seed.serviceLabel)
+            val serviceJaxrs =
+              fragments
+                .mapNotNull { fragment -> fragment.serviceJaxrs }
+                .distinct()
+                .singleOrNull()
+                ?: run {
+                  require(fragments.mapNotNull { fragment -> fragment.serviceJaxrs }.distinct().size <= 1) {
+                    "OpenAPI service '$serviceName' has conflicting x-sunday-jaxrs metadata. " +
+                      "Move REST client metadata to the API root, a single service tag, or align the operation metadata."
+                  }
+                  null
+                }
             ServiceFragment(
               service =
                 GeneratedService(
@@ -102,6 +115,7 @@ class OpenApiToGeneratedApi(
                   baseUriParameters = servers.firstOrNull()?.serverVariables().orEmpty(),
                   operations = operations,
                   auth = auth(zanzibar = rootZanzibar()),
+                  jaxrs = serviceJaxrs,
                   media = GeneratedMedia(),
                 ),
               identity = seed.identity,
@@ -123,6 +137,7 @@ class OpenApiToGeneratedApi(
         val operation = pathItem.mapValue(method) ?: return@mapNotNull null
         val operationId = operation.generatedOperationId(method, path)
         val seed = serviceIdentitySeed(path, pathService, operation)
+        val serviceJaxrs = serviceJaxrs(seed.serviceTag, pathItem, operation)
         OperationFragment(
           operation =
             GeneratedOperation(
@@ -144,9 +159,27 @@ class OpenApiToGeneratedApi(
             ),
           identity = operation.compositionOperationIdentity(operationId),
           seed = seed,
+          serviceJaxrs = serviceJaxrs,
         )
       }
     }
+
+  private fun OpenApiSourceDocument.serviceJaxrs(
+    serviceTag: String?,
+    pathItem: Map<*, *>,
+    operation: Map<*, *>,
+  ): GeneratedJaxrs? =
+    tagJaxrs(serviceTag)
+      .mergeWith(pathItem.jaxrs())
+      .mergeWith(operation.jaxrs())
+
+  private fun OpenApiSourceDocument.tagJaxrs(serviceTag: String?): GeneratedJaxrs? =
+    serviceTag
+      ?.let { tagName ->
+        listValue("tags")
+          .mapNotNull { tag -> tag as? Map<*, *> }
+          .firstOrNull { tag -> tag["name"] == tagName }
+      }?.jaxrs()
 
   private fun OpenApiSourceDocument.parameter(value: Any?): GeneratedParameter? {
     val parameter = resolveParameter(value) ?: return null
@@ -656,7 +689,11 @@ class OpenApiToGeneratedApi(
 
     val taggedService = operation.taggedServiceLabel(path)
     if (taggedService != null) {
-      return ServiceIdentitySeed(taggedService, GeneratedIdentity.native(normalizedCompositionId(taggedService)))
+      return ServiceIdentitySeed(
+        taggedService,
+        GeneratedIdentity.native(normalizedCompositionId(taggedService)),
+        serviceTag = taggedService,
+      )
     }
 
     val serviceLabel = title.removeSuffix(" API")
@@ -873,9 +910,49 @@ class OpenApiToGeneratedApi(
       val tag = value as? Map<*, *> ?: return@mapNotNull null
       GeneratedTag(
         name = tag["name"] as? String ?: return@mapNotNull null,
+        jaxrs = tag.jaxrs(),
         documentation = documentation(description = tag["description"] as? String),
       )
     }
+
+  private fun Map<*, *>.jaxrs(): GeneratedJaxrs? {
+    val restClient = mapValue("x-sunday-jaxrs")?.mapValue("rest-client")?.restClient()
+    return GeneratedJaxrs(restClient = restClient).takeUnless { it == GeneratedJaxrs() }
+  }
+
+  private fun OpenApiSourceDocument.jaxrs(): GeneratedJaxrs? = source.jaxrs()
+
+  private fun Map<*, *>.restClient(): GeneratedJaxrsRestClient? =
+    GeneratedJaxrsRestClient(
+      configKey = stringValue("config-key") ?: stringValue("configKey"),
+      oidcClient = stringValue("oidc-client") ?: stringValue("oidcClient"),
+      providers = listValue("providers").mapNotNull { provider -> (provider as? String)?.trimToNull() }.distinct(),
+    ).takeUnless { it == GeneratedJaxrsRestClient() }
+
+  private fun GeneratedJaxrs?.mergeWith(other: GeneratedJaxrs?): GeneratedJaxrs? {
+    if (this == null) {
+      return other
+    }
+    if (other == null) {
+      return this
+    }
+    val restClient = restClient.mergeWith(other.restClient)
+    return copy(restClient = restClient).takeUnless { it == GeneratedJaxrs() }
+  }
+
+  private fun GeneratedJaxrsRestClient?.mergeWith(other: GeneratedJaxrsRestClient?): GeneratedJaxrsRestClient? {
+    if (this == null) {
+      return other
+    }
+    if (other == null) {
+      return this
+    }
+    return GeneratedJaxrsRestClient(
+      configKey = other.configKey ?: configKey,
+      oidcClient = other.oidcClient ?: oidcClient,
+      providers = (providers + other.providers).distinct(),
+    ).takeUnless { it == GeneratedJaxrsRestClient() }
+  }
 
   private fun Map<*, *>.serverVariables(): List<GeneratedParameter> =
     mapValue("variables").orEmpty().mapNotNull { (nameValue, value) ->
@@ -1024,12 +1101,14 @@ class OpenApiToGeneratedApi(
   private data class ServiceIdentitySeed(
     val serviceLabel: String,
     val identity: GeneratedIdentity,
+    val serviceTag: String? = null,
   )
 
   private data class OperationFragment(
     val operation: GeneratedOperation,
     val identity: GeneratedIdentity,
     val seed: ServiceIdentitySeed,
+    val serviceJaxrs: GeneratedJaxrs?,
   )
 
   private data class ServiceFragment(

--- a/generator/src/main/kotlin/io/outfoxx/sunday/generator/ir/OpenApiToGeneratedApi.kt
+++ b/generator/src/main/kotlin/io/outfoxx/sunday/generator/ir/OpenApiToGeneratedApi.kt
@@ -95,18 +95,14 @@ class OpenApiToGeneratedApi(
           .takeIf { it.isNotEmpty() }
           ?.let {
             val serviceName = serviceName(seed.serviceLabel)
-            val serviceJaxrs =
+            val serviceJaxrsValues =
               fragments
                 .mapNotNull { fragment -> fragment.serviceJaxrs }
                 .distinct()
-                .singleOrNull()
-                ?: run {
-                  require(fragments.mapNotNull { fragment -> fragment.serviceJaxrs }.distinct().size <= 1) {
-                    "OpenAPI service '$serviceName' has conflicting x-sunday-jaxrs metadata. " +
-                      "Move REST client metadata to the API root, a single service tag, or align the operation metadata."
-                  }
-                  null
-                }
+            require(serviceJaxrsValues.size <= 1) {
+              "OpenAPI service '$serviceName' has conflicting x-sunday-jaxrs metadata. " +
+                "Move REST client metadata to the API root, a single service tag, or align the operation metadata."
+            }
             ServiceFragment(
               service =
                 GeneratedService(
@@ -115,7 +111,7 @@ class OpenApiToGeneratedApi(
                   baseUriParameters = servers.firstOrNull()?.serverVariables().orEmpty(),
                   operations = operations,
                   auth = auth(zanzibar = rootZanzibar()),
-                  jaxrs = serviceJaxrs,
+                  jaxrs = serviceJaxrsValues.singleOrNull(),
                   media = GeneratedMedia(),
                 ),
               identity = seed.identity,
@@ -928,31 +924,6 @@ class OpenApiToGeneratedApi(
       oidcClient = stringValue("oidc-client") ?: stringValue("oidcClient"),
       providers = listValue("providers").mapNotNull { provider -> (provider as? String)?.trimToNull() }.distinct(),
     ).takeUnless { it == GeneratedJaxrsRestClient() }
-
-  private fun GeneratedJaxrs?.mergeWith(other: GeneratedJaxrs?): GeneratedJaxrs? {
-    if (this == null) {
-      return other
-    }
-    if (other == null) {
-      return this
-    }
-    val restClient = restClient.mergeWith(other.restClient)
-    return copy(restClient = restClient).takeUnless { it == GeneratedJaxrs() }
-  }
-
-  private fun GeneratedJaxrsRestClient?.mergeWith(other: GeneratedJaxrsRestClient?): GeneratedJaxrsRestClient? {
-    if (this == null) {
-      return other
-    }
-    if (other == null) {
-      return this
-    }
-    return GeneratedJaxrsRestClient(
-      configKey = other.configKey ?: configKey,
-      oidcClient = other.oidcClient ?: oidcClient,
-      providers = (providers + other.providers).distinct(),
-    ).takeUnless { it == GeneratedJaxrsRestClient() }
-  }
 
   private fun Map<*, *>.serverVariables(): List<GeneratedParameter> =
     mapValue("variables").orEmpty().mapNotNull { (nameValue, value) ->

--- a/generator/src/main/kotlin/io/outfoxx/sunday/generator/ir/RamlToGeneratedApi.kt
+++ b/generator/src/main/kotlin/io/outfoxx/sunday/generator/ir/RamlToGeneratedApi.kt
@@ -216,6 +216,7 @@ class RamlToGeneratedApi(
       models = models(document, api, shapeIndex, rootLocation, localModels),
       problems = problems(document, api),
       auth = apiAuth,
+      jaxrs = api.jaxrs(),
       media = apiMedia,
       targets = api.targets(),
       tags = api.tags.mapNotNull { tag -> tag.generatedTag() },
@@ -306,6 +307,7 @@ class RamlToGeneratedApi(
           baseUriParameters = baseUriParameters,
           operations = operations,
           auth = apiAuth,
+          jaxrs = endPoints.serviceJaxrs(),
           media = apiMedia,
           documentation = endPoints.firstOrNull()?.root?.let { documentation(it.summary, it.description) },
         )
@@ -727,6 +729,34 @@ class RamlToGeneratedApi(
           ?.distinct()
           .orEmpty(),
     ).takeUnless { it == GeneratedJaxrs() }
+
+  private fun CustomizableElement.jaxrs(): GeneratedJaxrs? =
+    GeneratedJaxrs(restClient = jaxrsRestClient()).takeUnless { it == GeneratedJaxrs() }
+
+  private fun List<EndPoint>.serviceJaxrs(): GeneratedJaxrs? {
+    val values = mapNotNull { endPoint -> endPoint.root.jaxrs() }.distinct()
+    require(values.size <= 1) {
+      "RAML service endpoints have conflicting sunday.jaxrsRestClient metadata. " +
+        "Move REST client metadata to the API root or align endpoint metadata."
+    }
+    return values.singleOrNull()
+  }
+
+  private fun CustomizableElement.jaxrsRestClient(): GeneratedJaxrsRestClient? =
+    (findAnnotation(APIAnnotationName.JaxrsRestClient, null) as? ObjectNode)
+      ?.let { restClient ->
+        GeneratedJaxrsRestClient(
+          configKey = restClient.getValue("configKey") ?: restClient.getValue("config-key"),
+          oidcClient = restClient.getValue("oidcClient") ?: restClient.getValue("oidc-client"),
+          providers =
+            restClient
+              .get<ArrayNode>("providers")
+              ?.members()
+              ?.mapNotNull { provider -> provider.stringValue?.trimToNull() }
+              ?.distinct()
+              .orEmpty(),
+        )
+      }?.takeUnless { it == GeneratedJaxrsRestClient() }
 
   private fun Operation.modeFlag(name: APIAnnotationName): GeneratedModeFlag? =
     GeneratedModeFlag(

--- a/generator/src/main/kotlin/io/outfoxx/sunday/generator/kotlin/KotlinJAXRSIrGenerator.kt
+++ b/generator/src/main/kotlin/io/outfoxx/sunday/generator/kotlin/KotlinJAXRSIrGenerator.kt
@@ -48,6 +48,7 @@ import io.outfoxx.sunday.generator.common.HttpStatus
 import io.outfoxx.sunday.generator.genError
 import io.outfoxx.sunday.generator.ir.GeneratedApi
 import io.outfoxx.sunday.generator.ir.GeneratedCollectionKind
+import io.outfoxx.sunday.generator.ir.GeneratedJaxrsRestClient
 import io.outfoxx.sunday.generator.ir.GeneratedModel
 import io.outfoxx.sunday.generator.ir.GeneratedModelProperty
 import io.outfoxx.sunday.generator.ir.GeneratedOperation
@@ -381,7 +382,10 @@ class KotlinJAXRSIrGenerator(
       servicePath()
         ?.takeIf { path -> path.isNotEmpty() }
         ?.let { path -> typeBuilder.addAnnotation(jaxRsTypes.path, path) }
-      typeBuilder.addRegisterRestClientAnnotation(expandedBaseUri())
+      typeBuilder.addQuarkusRestClientAnnotations(
+        expandedBaseUri(),
+        api.jaxrs?.restClient.mergeWith(jaxrs?.restClient),
+      )
     }
 
     if (defaultMediaTypes.isNotEmpty()) {
@@ -430,10 +434,11 @@ class KotlinJAXRSIrGenerator(
         .addModifiers(KModifier.PUBLIC)
 
     typeBuilder.addAnnotation(jaxRsTypes.path, aggregateServicePath(services))
-    typeBuilder.addRegisterRestClientAnnotation(
+    typeBuilder.addQuarkusRestClientAnnotations(
       services.firstNotNullOfOrNull { service ->
         service.service.expandedBaseUri()
       },
+      api.jaxrs?.restClient,
     )
 
     if (defaultMediaTypes.isNotEmpty()) {
@@ -1057,7 +1062,10 @@ class KotlinJAXRSIrGenerator(
     return UriTemplate.buildFromTemplate(baseUri).build().expand(parameterValues)
   }
 
-  private fun TypeSpec.Builder.addRegisterRestClientAnnotation(baseUri: String?) {
+  private fun TypeSpec.Builder.addQuarkusRestClientAnnotations(
+    baseUri: String?,
+    restClient: GeneratedJaxrsRestClient?,
+  ) {
     if (generationMode != Client || !options.quarkus) {
       return
     }
@@ -1067,9 +1075,48 @@ class KotlinJAXRSIrGenerator(
       AnnotationSpec
         .builder(annotation)
         .apply {
+          restClient?.configKey?.let { value -> addMember("configKey = %S", value) }
           baseUri?.let { value -> addMember("baseUri = %S", value) }
         }.build(),
     )
+    restClient?.oidcClient?.let { clientName ->
+      jaxRsTypes.oidcClientFilter?.let { oidcClientFilter ->
+        addAnnotation(
+          AnnotationSpec
+            .builder(oidcClientFilter)
+            .addMember("%S", clientName)
+            .build(),
+        )
+      }
+    }
+    restClient
+      ?.providers
+      .orEmpty()
+      .map { provider -> ClassName.bestGuess(provider) }
+      .forEach { provider ->
+        jaxRsTypes.registerProvider?.let { registerProvider ->
+          addAnnotation(
+            AnnotationSpec
+              .builder(registerProvider)
+              .addMember("%T::class", provider)
+              .build(),
+          )
+        }
+      }
+  }
+
+  private fun GeneratedJaxrsRestClient?.mergeWith(other: GeneratedJaxrsRestClient?): GeneratedJaxrsRestClient? {
+    if (this == null) {
+      return other
+    }
+    if (other == null) {
+      return this
+    }
+    return GeneratedJaxrsRestClient(
+      configKey = other.configKey ?: configKey,
+      oidcClient = other.oidcClient ?: oidcClient,
+      providers = (providers + other.providers).distinct(),
+    ).takeUnless { it == GeneratedJaxrsRestClient() }
   }
 
   private fun uniqueContextParameterName(

--- a/generator/src/main/kotlin/io/outfoxx/sunday/generator/kotlin/KotlinJAXRSIrGenerator.kt
+++ b/generator/src/main/kotlin/io/outfoxx/sunday/generator/kotlin/KotlinJAXRSIrGenerator.kt
@@ -81,6 +81,7 @@ import io.outfoxx.sunday.generator.ir.emit.resolvedTypeUri
 import io.outfoxx.sunday.generator.ir.emit.sseEnabled
 import io.outfoxx.sunday.generator.ir.emit.target
 import io.outfoxx.sunday.generator.ir.emit.withLocation
+import io.outfoxx.sunday.generator.ir.mergeWith
 import io.outfoxx.sunday.generator.kotlin.KotlinTypeRegistry.Option.ImplementModel
 import io.outfoxx.sunday.generator.kotlin.KotlinTypeRegistry.Option.JacksonAnnotations
 import io.outfoxx.sunday.generator.kotlin.KotlinTypeRegistry.Option.ValidationConstraints
@@ -1103,20 +1104,6 @@ class KotlinJAXRSIrGenerator(
           )
         }
       }
-  }
-
-  private fun GeneratedJaxrsRestClient?.mergeWith(other: GeneratedJaxrsRestClient?): GeneratedJaxrsRestClient? {
-    if (this == null) {
-      return other
-    }
-    if (other == null) {
-      return this
-    }
-    return GeneratedJaxrsRestClient(
-      configKey = other.configKey ?: configKey,
-      oidcClient = other.oidcClient ?: oidcClient,
-      providers = (providers + other.providers).distinct(),
-    ).takeUnless { it == GeneratedJaxrsRestClient() }
   }
 
   private fun uniqueContextParameterName(

--- a/generator/src/main/kotlin/io/outfoxx/sunday/generator/kotlin/KotlinJAXRSIrGenerator.kt
+++ b/generator/src/main/kotlin/io/outfoxx/sunday/generator/kotlin/KotlinJAXRSIrGenerator.kt
@@ -1093,7 +1093,7 @@ class KotlinJAXRSIrGenerator(
     restClient
       ?.providers
       .orEmpty()
-      .map { provider -> ClassName.bestGuess(provider) }
+      .map { provider -> provider.providerClassName() }
       .forEach { provider ->
         jaxRsTypes.registerProvider?.let { registerProvider ->
           addAnnotation(
@@ -1105,6 +1105,13 @@ class KotlinJAXRSIrGenerator(
         }
       }
   }
+
+  private fun String.providerClassName(): ClassName =
+    try {
+      ClassName.bestGuess(this)
+    } catch (error: IllegalArgumentException) {
+      genError("Invalid provider class name '$this' in REST client metadata: ${error.message}")
+    }
 
   private fun uniqueContextParameterName(
     contextParameter: String,

--- a/generator/src/main/kotlin/io/outfoxx/sunday/generator/kotlin/utils/JaxRsTypes.kt
+++ b/generator/src/main/kotlin/io/outfoxx/sunday/generator/kotlin/utils/JaxRsTypes.kt
@@ -125,6 +125,8 @@ interface JaxRsTypes {
   // Client Only
   val clientHeaderParam: ClassName? get() = null
   val registerRestClient: ClassName? get() = null
+  val registerProvider: ClassName? get() = null
+  val oidcClientFilter: ClassName? get() = null
 
   fun httpMethod(method: String): ClassName? =
     try {
@@ -296,5 +298,7 @@ interface JaxRsTypes {
 
     override val clientHeaderParam = ClassName("org.eclipse.microprofile.rest.client.annotation", "ClientHeaderParam")
     override val registerRestClient = ClassName("org.eclipse.microprofile.rest.client.inject", "RegisterRestClient")
+    override val registerProvider = ClassName("org.eclipse.microprofile.rest.client.annotation", "RegisterProvider")
+    override val oidcClientFilter = ClassName("io.quarkus.oidc.client.filter", "OidcClientFilter")
   }
 }

--- a/generator/src/test/kotlin/io/outfoxx/sunday/generator/ir/GeneratedApiComposerTest.kt
+++ b/generator/src/test/kotlin/io/outfoxx/sunday/generator/ir/GeneratedApiComposerTest.kt
@@ -102,6 +102,45 @@ class GeneratedApiComposerTest {
   }
 
   @Test
+  fun `merges jaxrs metadata without dropping non rest client fields`() {
+
+    val merged =
+      GeneratedJaxrs(
+        asynchronous = true,
+        reactive = false,
+        sse = GeneratedModeFlag(client = true),
+        context = listOf("uriInfo"),
+        restClient = GeneratedJaxrsRestClient(configKey = "api", providers = listOf("io.test.ApiFilter")),
+      ).mergeWith(
+        GeneratedJaxrs(
+          reactive = true,
+          jsonBody = GeneratedModeFlag(server = true),
+          context = listOf("request"),
+          restClient = GeneratedJaxrsRestClient(oidcClient = "graphs", providers = listOf("io.test.GraphsFilter")),
+        ),
+      )
+
+    assertThat(
+      merged,
+      equalTo(
+        GeneratedJaxrs(
+          asynchronous = true,
+          reactive = true,
+          sse = GeneratedModeFlag(client = true),
+          jsonBody = GeneratedModeFlag(server = true),
+          context = listOf("uriInfo", "request"),
+          restClient =
+            GeneratedJaxrsRestClient(
+              configKey = "api",
+              oidcClient = "graphs",
+              providers = listOf("io.test.ApiFilter", "io.test.GraphsFilter"),
+            ),
+        ),
+      ),
+    )
+  }
+
+  @Test
   fun `rejects api id mismatches with api id override guidance`() {
 
     val failure =

--- a/generator/src/test/kotlin/io/outfoxx/sunday/generator/ir/GeneratedApiComposerTest.kt
+++ b/generator/src/test/kotlin/io/outfoxx/sunday/generator/ir/GeneratedApiComposerTest.kt
@@ -80,6 +80,28 @@ class GeneratedApiComposerTest {
   }
 
   @Test
+  fun `composes api level jaxrs metadata from later fragments`() {
+
+    val restClient =
+      GeneratedJaxrsRestClient(
+        configKey = "platform",
+        oidcClient = "graphs",
+        providers = listOf("io.test.client.GraphsClientFilter"),
+      )
+    val openApi = fragment(apiName = "Craft HTTP API")
+    val asyncApi =
+      fragment(
+        kind = GeneratedSourceSpec.Kind.ASYNCAPI,
+        apiName = "Craft Events API",
+        apiJaxrs = GeneratedJaxrs(restClient = restClient),
+      )
+
+    val api = GeneratedApiComposer().compose(listOf(openApi, asyncApi))
+
+    assertThat(api.jaxrs, equalTo(GeneratedJaxrs(restClient = restClient)))
+  }
+
+  @Test
   fun `rejects api id mismatches with api id override guidance`() {
 
     val failure =
@@ -340,6 +362,7 @@ class GeneratedApiComposerTest {
     operationIdentities: Map<GeneratedOperationIdentityKey, GeneratedIdentity> = mapOf(),
     models: List<GeneratedModel> = listOf(),
     modelIdentities: Map<String, GeneratedIdentity> = mapOf(),
+    apiJaxrs: GeneratedJaxrs? = null,
   ): GeneratedApiFragment =
     GeneratedApiFragment(
       api =
@@ -348,6 +371,7 @@ class GeneratedApiComposerTest {
           source = GeneratedSourceSpec(kind = kind, location = "$apiName.yaml"),
           services = services,
           models = models,
+          jaxrs = apiJaxrs,
         ),
       apiId = apiId,
       serviceIdentities = serviceIdentities,

--- a/generator/src/test/kotlin/io/outfoxx/sunday/generator/ir/OpenApiToGeneratedApiTest.kt
+++ b/generator/src/test/kotlin/io/outfoxx/sunday/generator/ir/OpenApiToGeneratedApiTest.kt
@@ -202,6 +202,34 @@ class OpenApiToGeneratedApiTest {
   }
 
   @Test
+  fun `maps OpenAPI JAX-RS REST client metadata from root and service tags`(
+    @ResourceUri("openapi/ir/jaxrs-rest-client-3.1.yaml") testUri: URI,
+  ) {
+    val api = OpenApiToGeneratedApi(GeneratedApiIrOptions(deriveServicesFromTags = true)).convert(testUri)
+
+    assertEquals(
+      GeneratedJaxrs(restClient = GeneratedJaxrsRestClient(configKey = "platform")),
+      api.jaxrs,
+    )
+    assertEquals(
+      GeneratedJaxrs(
+        restClient =
+          GeneratedJaxrsRestClient(
+            configKey = "graphs",
+            oidcClient = "graphs",
+            providers = listOf("io.test.client.GraphsClientFilter"),
+          ),
+      ),
+      api.services.single().jaxrs,
+    )
+    assertEquals(api.services.single().name, "GraphsService")
+    assertEquals(
+      api.services.single().jaxrs,
+      api.tags.single().jaxrs,
+    )
+  }
+
+  @Test
   fun `maps OpenAPI empty schemas to any JSON values`(
     @ResourceUri("openapi/ir/any-json-3.1.yaml") testUri: URI,
   ) {

--- a/generator/src/test/kotlin/io/outfoxx/sunday/generator/kotlin/jaxrs/KotlinJAXRSIrGeneratorTest.kt
+++ b/generator/src/test/kotlin/io/outfoxx/sunday/generator/kotlin/jaxrs/KotlinJAXRSIrGeneratorTest.kt
@@ -26,6 +26,8 @@ import io.outfoxx.sunday.generator.ir.GeneratedAdditionalProperties
 import io.outfoxx.sunday.generator.ir.GeneratedApi
 import io.outfoxx.sunday.generator.ir.GeneratedApiIrExporter
 import io.outfoxx.sunday.generator.ir.GeneratedAuth
+import io.outfoxx.sunday.generator.ir.GeneratedJaxrs
+import io.outfoxx.sunday.generator.ir.GeneratedJaxrsRestClient
 import io.outfoxx.sunday.generator.ir.GeneratedModel
 import io.outfoxx.sunday.generator.ir.GeneratedModelProperty
 import io.outfoxx.sunday.generator.ir.GeneratedOperation
@@ -1229,6 +1231,92 @@ class KotlinJAXRSIrGeneratorTest {
 
   @OptIn(ExperimentalCompilerApi::class)
   @Test
+  fun `generates Quarkus REST client metadata on non-aggregate services`() {
+    val typeRegistry =
+      KotlinTypeRegistry(
+        "io.test",
+        null,
+        GenerationMode.Client,
+        setOf(),
+        problemLibrary = KotlinProblemLibrary.ZALANDO,
+        problemRfc = KotlinProblemRfc.RFC7807,
+      )
+
+    KotlinJAXRSIrGenerator(
+      aggregateServicesApi(
+        baseUri = "http://localhost:9080",
+        apiRestClient = GeneratedJaxrsRestClient(configKey = "platform"),
+        serviceRestClient =
+          GeneratedJaxrsRestClient(
+            configKey = "graphs",
+            oidcClient = "graphs",
+            providers = listOf("io.test.client.GraphsClientFilter"),
+          ),
+      ),
+      typeRegistry,
+      testOptions(quarkus = true),
+    ).generateServiceTypes()
+
+    val builtTypes = typeRegistry.buildTypes()
+    val usersSource = kotlinSource("io.test.service", findType("io.test.service.UsersAPI", builtTypes))
+
+    assertEquals(KotlinCompilation.ExitCode.OK, compileTypes(builtTypes))
+    assertTrue(usersSource.contains("@RegisterRestClient("), usersSource)
+    assertTrue(usersSource.contains("configKey = \"graphs\""), usersSource)
+    assertTrue(usersSource.contains("baseUri = \"http://localhost:9080\""), usersSource)
+    assertTrue(usersSource.contains("@OidcClientFilter(\"graphs\")"), usersSource)
+    assertTrue(usersSource.contains("@RegisterProvider(GraphsClientFilter::class)"), usersSource)
+  }
+
+  @OptIn(ExperimentalCompilerApi::class)
+  @Test
+  fun `generates aggregate Quarkus REST client metadata from root only`() {
+    val typeRegistry =
+      KotlinTypeRegistry(
+        "io.test",
+        null,
+        GenerationMode.Client,
+        setOf(),
+        problemLibrary = KotlinProblemLibrary.ZALANDO,
+        problemRfc = KotlinProblemRfc.RFC7807,
+      )
+
+    KotlinJAXRSIrGenerator(
+      aggregateServicesApi(
+        baseUri = "http://localhost:9080",
+        apiRestClient =
+          GeneratedJaxrsRestClient(
+            configKey = "platform",
+            oidcClient = "public",
+            providers = listOf("io.test.client.GraphsClientFilter"),
+          ),
+        serviceRestClient = GeneratedJaxrsRestClient(configKey = "graphs", oidcClient = "graphs"),
+      ),
+      typeRegistry,
+      testOptions(
+        quarkus = true,
+        aggregateServices = true,
+        aggregateServiceName = "TurnPostAPI",
+      ),
+    ).generateServiceTypes()
+
+    val builtTypes = typeRegistry.buildTypes()
+    val aggregateSource = kotlinSource("io.test.service", findType("io.test.service.TurnPostAPI", builtTypes))
+    val usersSource = kotlinSource("io.test.service", findType("io.test.service.UsersAPI", builtTypes))
+
+    assertEquals(KotlinCompilation.ExitCode.OK, compileTypes(builtTypes))
+    assertTrue(aggregateSource.contains("@RegisterRestClient("), aggregateSource)
+    assertTrue(aggregateSource.contains("configKey = \"platform\""), aggregateSource)
+    assertTrue(aggregateSource.contains("baseUri = \"http://localhost:9080\""), aggregateSource)
+    assertTrue(aggregateSource.contains("@OidcClientFilter(\"public\")"), aggregateSource)
+    assertTrue(aggregateSource.contains("@RegisterProvider(GraphsClientFilter::class)"), aggregateSource)
+    assertFalse(usersSource.contains("@RegisterRestClient"), usersSource)
+    assertFalse(usersSource.contains("@OidcClientFilter"), usersSource)
+    assertFalse(usersSource.contains("@RegisterProvider"), usersSource)
+  }
+
+  @OptIn(ExperimentalCompilerApi::class)
+  @Test
   fun `treats OpenAPI empty schemas as Any in Kotlin JAX-RS`(
     @ResourceUri("openapi/ir/any-json-3.1.yaml") testUri: URI,
   ) {
@@ -2136,16 +2224,22 @@ class KotlinJAXRSIrGeneratorTest {
         ),
     )
 
-  private fun aggregateServicesApi(baseUri: String? = null): GeneratedApi =
+  private fun aggregateServicesApi(
+    baseUri: String? = null,
+    apiRestClient: GeneratedJaxrsRestClient? = null,
+    serviceRestClient: GeneratedJaxrsRestClient? = null,
+  ): GeneratedApi =
     GeneratedApi(
       name = "TurnPost API",
       source = GeneratedSourceSpec(kind = GeneratedSourceSpec.Kind.OPENAPI, location = "memory://turnpost"),
+      jaxrs = apiRestClient?.let { restClient -> GeneratedJaxrs(restClient = restClient) },
       services =
         listOf(
           GeneratedService(
             name = "UsersService",
             baseUri = baseUri,
             group = "Users",
+            jaxrs = serviceRestClient?.let { restClient -> GeneratedJaxrs(restClient = restClient) },
             operations =
               listOf(
                 GeneratedOperation(

--- a/generator/src/test/kotlin/io/outfoxx/sunday/generator/kotlin/jaxrs/KotlinJAXRSIrGeneratorTest.kt
+++ b/generator/src/test/kotlin/io/outfoxx/sunday/generator/kotlin/jaxrs/KotlinJAXRSIrGeneratorTest.kt
@@ -1268,6 +1268,35 @@ class KotlinJAXRSIrGeneratorTest {
     assertTrue(usersSource.contains("@RegisterProvider(GraphsClientFilter::class)"), usersSource)
   }
 
+  @Test
+  fun `reports invalid Quarkus REST client provider class names`() {
+    val typeRegistry =
+      KotlinTypeRegistry(
+        "io.test",
+        null,
+        GenerationMode.Client,
+        setOf(),
+        problemLibrary = KotlinProblemLibrary.ZALANDO,
+        problemRfc = KotlinProblemRfc.RFC7807,
+      )
+
+    val error =
+      assertThrows(GenerationException::class.java) {
+        KotlinJAXRSIrGenerator(
+          aggregateServicesApi(
+            serviceRestClient = GeneratedJaxrsRestClient(providers = listOf("not-a-class")),
+          ),
+          typeRegistry,
+          testOptions(quarkus = true),
+        ).generateServiceTypes()
+      }
+
+    assertTrue(
+      error.message?.contains("Invalid provider class name 'not-a-class' in REST client metadata") == true,
+      error.message,
+    )
+  }
+
   @OptIn(ExperimentalCompilerApi::class)
   @Test
   fun `generates aggregate Quarkus REST client metadata from root only`() {

--- a/generator/src/test/kotlin/io/quarkus/oidc/client/filter/OidcClientFilter.kt
+++ b/generator/src/test/kotlin/io/quarkus/oidc/client/filter/OidcClientFilter.kt
@@ -14,20 +14,11 @@
  * limitations under the License.
  */
 
-package io.outfoxx.sunday.generator.ir
+package io.quarkus.oidc.client.filter
 
-/**
- * Generated service declaration.
- */
-data class GeneratedService(
-  val name: String,
-  val baseUri: String? = null,
-  val baseUriParameters: List<GeneratedParameter> = listOf(),
-  val group: String? = null,
-  val operations: List<GeneratedOperation> = listOf(),
-  val auth: GeneratedAuth? = null,
-  val jaxrs: GeneratedJaxrs? = null,
-  val protocol: GeneratedProtocol? = null,
-  val media: GeneratedMedia? = null,
-  val documentation: GeneratedDocumentation? = null,
+// Quarkus OIDC client filter annotation to skip the dependency on Quarkus OIDC in generator tests
+
+@Target(AnnotationTarget.CLASS)
+annotation class OidcClientFilter(
+  val value: String = "",
 )

--- a/generator/src/test/kotlin/io/test/client/GraphsClientFilter.kt
+++ b/generator/src/test/kotlin/io/test/client/GraphsClientFilter.kt
@@ -14,20 +14,7 @@
  * limitations under the License.
  */
 
-package io.outfoxx.sunday.generator.ir
+package io.test.client
 
-/**
- * Generated service declaration.
- */
-data class GeneratedService(
-  val name: String,
-  val baseUri: String? = null,
-  val baseUriParameters: List<GeneratedParameter> = listOf(),
-  val group: String? = null,
-  val operations: List<GeneratedOperation> = listOf(),
-  val auth: GeneratedAuth? = null,
-  val jaxrs: GeneratedJaxrs? = null,
-  val protocol: GeneratedProtocol? = null,
-  val media: GeneratedMedia? = null,
-  val documentation: GeneratedDocumentation? = null,
-)
+/** Test provider used by generated REST client annotation compile checks. */
+class GraphsClientFilter

--- a/generator/src/test/kotlin/org/eclipse/microprofile/rest/client/annotation/RegisterProvider.kt
+++ b/generator/src/test/kotlin/org/eclipse/microprofile/rest/client/annotation/RegisterProvider.kt
@@ -14,20 +14,13 @@
  * limitations under the License.
  */
 
-package io.outfoxx.sunday.generator.ir
+package org.eclipse.microprofile.rest.client.annotation
 
-/**
- * Generated service declaration.
- */
-data class GeneratedService(
-  val name: String,
-  val baseUri: String? = null,
-  val baseUriParameters: List<GeneratedParameter> = listOf(),
-  val group: String? = null,
-  val operations: List<GeneratedOperation> = listOf(),
-  val auth: GeneratedAuth? = null,
-  val jaxrs: GeneratedJaxrs? = null,
-  val protocol: GeneratedProtocol? = null,
-  val media: GeneratedMedia? = null,
-  val documentation: GeneratedDocumentation? = null,
+import kotlin.reflect.KClass
+
+// MicroProfile Rest Client annotations to skip the dependency on the MicroProfile Rest Client API
+
+@Target(AnnotationTarget.CLASS)
+annotation class RegisterProvider(
+  val value: KClass<*>,
 )

--- a/generator/src/test/kotlin/org/eclipse/microprofile/rest/client/inject/RegisterRestClient.kt
+++ b/generator/src/test/kotlin/org/eclipse/microprofile/rest/client/inject/RegisterRestClient.kt
@@ -21,4 +21,5 @@ package org.eclipse.microprofile.rest.client.inject
 @Target(AnnotationTarget.CLASS)
 annotation class RegisterRestClient(
   val baseUri: String = "",
+  val configKey: String = "",
 )

--- a/generator/src/test/resources/openapi/ir/jaxrs-rest-client-3.1.yaml
+++ b/generator/src/test/resources/openapi/ir/jaxrs-rest-client-3.1.yaml
@@ -1,0 +1,25 @@
+openapi: 3.1.0
+info:
+  title: Platform API
+  version: 1.0.0
+x-sunday-jaxrs:
+  rest-client:
+    config-key: platform
+servers:
+  - url: http://localhost:9080
+tags:
+  - name: Graphs
+    x-sunday-jaxrs:
+      rest-client:
+        config-key: graphs
+        oidc-client: graphs
+        providers:
+          - io.test.client.GraphsClientFilter
+paths:
+  /graphs:
+    get:
+      tags: [Graphs]
+      operationId: listGraphs
+      responses:
+        '204':
+          description: No content


### PR DESCRIPTION
## Summary

- add durable IR for JAX-RS REST client metadata
- map OpenAPI `x-sunday-jaxrs.rest-client` from root, tags, paths, and operations
- map RAML `sunday.jaxrsRestClient`
- emit Quarkus `@RegisterRestClient`, `@OidcClientFilter`, and `@RegisterProvider` annotations for JAX-RS clients
- keep aggregate JAX-RS clients rooted on API-level metadata so tag/service metadata is ignored for aggregate registration

## Validation

- `./gradlew :generator:test --tests io.outfoxx.sunday.generator.ir.OpenApiToGeneratedApiTest --tests io.outfoxx.sunday.generator.kotlin.jaxrs.KotlinJAXRSIrGeneratorTest --rerun-tasks`
- `./gradlew :generator:ktlintCheck --rerun-tasks`
- `./gradlew :generator:check`
- `git diff --check`
