### PR TITLE
Support explicit OpenAPI service group tags

### DIFF
--- a/docs/sunday-ir-format.md
+++ b/docs/sunday-ir-format.md
@@ -45,7 +45,7 @@ Every major IR level may carry `documentation` with `summary` and/or `descriptio
 
 ## Tags
 
-APIs may carry source-declared `tags`, each with a name and optional documentation. `GeneratedOperation.tags` carries operation tag references as source-fidelity metadata. Emitters can later decide whether tags affect service grouping, module placement, generated documentation, or no generated output.
+APIs may carry source-declared `tags`, each with a name and optional documentation. OpenAPI tags may set `x-sunday-service-group: true`, which maps to `GeneratedTag.serviceGroup` and marks that tag as an explicit service grouping tag. `GeneratedOperation.tags` carries operation tag references as source-fidelity metadata. The `-services-from-tags` option remains a broad convenience mode that treats every operation tag as a service grouping tag; without that option, OpenAPI service grouping only uses tags marked with `x-sunday-service-group: true`. Other tag metadata, such as `x-sunday-policy` and `x-sunday-jaxrs`, does not imply service grouping.
 
 ## Lifecycle Metadata
 

--- a/generator/src/main/kotlin/io/outfoxx/sunday/generator/ir/GeneratedTag.kt
+++ b/generator/src/main/kotlin/io/outfoxx/sunday/generator/ir/GeneratedTag.kt
@@ -21,6 +21,7 @@ package io.outfoxx.sunday.generator.ir
  */
 data class GeneratedTag(
   val name: String,
+  val serviceGroup: Boolean = false,
   val policy: GeneratedPolicy? = null,
   val jaxrs: GeneratedJaxrs? = null,
   val documentation: GeneratedDocumentation? = null,

--- a/generator/src/main/kotlin/io/outfoxx/sunday/generator/ir/OpenApiToGeneratedApi.kt
+++ b/generator/src/main/kotlin/io/outfoxx/sunday/generator/ir/OpenApiToGeneratedApi.kt
@@ -712,7 +712,7 @@ class OpenApiToGeneratedApi(
       return ServiceIdentitySeed(serviceLabel, GeneratedIdentity.native(normalizedCompositionId(serviceLabel)))
     }
 
-    val taggedService = operation.taggedServiceLabel(path)
+    val taggedService = taggedServiceLabel(operation, path)
     if (taggedService != null) {
       return ServiceIdentitySeed(
         taggedService,
@@ -725,17 +725,33 @@ class OpenApiToGeneratedApi(
     return ServiceIdentitySeed(serviceLabel, GeneratedIdentity.native(normalizedCompositionId(serviceLabel)))
   }
 
-  private fun Map<*, *>.taggedServiceLabel(path: String): String? {
-    if (!options.deriveServicesFromTags) {
-      return null
-    }
+  private fun OpenApiSourceDocument.taggedServiceLabel(
+    operation: Map<*, *>,
+    path: String,
+  ): String? {
+    val tags =
+      operation
+        .listValue("tags")
+        .mapNotNull { tag -> (tag as? String)?.trimToNull() }
+        .distinct()
+    val serviceTags =
+      if (options.deriveServicesFromTags) {
+        tags
+      } else {
+        val serviceGroupTags =
+          listValue("tags")
+            .mapNotNull { tag -> tag as? Map<*, *> }
+            .filter { tag -> tag.serviceGroup() }
+            .mapNotNull { tag -> (tag["name"] as? String)?.trimToNull() }
+            .toSet()
+        tags.filter { tag -> tag in serviceGroupTags }
+      }
 
-    val tags = listValue("tags").mapNotNull { tag -> (tag as? String)?.trimToNull() }.distinct()
-    require(tags.size <= 1) {
-      "OpenAPI path '$path' operation has multiple service tags (${tags.joinToString()}). " +
+    require(serviceTags.size <= 1) {
+      "OpenAPI path '$path' operation has multiple service tags (${serviceTags.joinToString()}). " +
         "Add x-sunday-service to select one generated service explicitly."
     }
-    return tags.singleOrNull()
+    return serviceTags.singleOrNull()
   }
 
   private fun Map<*, *>.generatedOperationId(
@@ -951,11 +967,14 @@ class OpenApiToGeneratedApi(
       val tag = value as? Map<*, *> ?: return@mapNotNull null
       GeneratedTag(
         name = tag["name"] as? String ?: return@mapNotNull null,
+        serviceGroup = tag.serviceGroup(),
         policy = tag.policy(),
         jaxrs = tag.jaxrs(),
         documentation = documentation(description = tag["description"] as? String),
       )
     }
+
+  private fun Map<*, *>.serviceGroup(): Boolean = booleanValue("x-sunday-service-group") == true
 
   private fun Map<*, *>.jaxrs(): GeneratedJaxrs? {
     val restClient = mapValue("x-sunday-jaxrs")?.mapValue("rest-client")?.restClient()

--- a/generator/src/test/kotlin/io/outfoxx/sunday/generator/ir/GeneratedApiYamlTest.kt
+++ b/generator/src/test/kotlin/io/outfoxx/sunday/generator/ir/GeneratedApiYamlTest.kt
@@ -66,6 +66,7 @@ class GeneratedApiYamlTest {
           listOf(
             GeneratedTag(
               name = "projects",
+              serviceGroup = true,
               policy =
                 GeneratedPolicy(
                   timeout = "PT5S",

--- a/generator/src/test/kotlin/io/outfoxx/sunday/generator/ir/OpenApiToGeneratedApiTest.kt
+++ b/generator/src/test/kotlin/io/outfoxx/sunday/generator/ir/OpenApiToGeneratedApiTest.kt
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.io.TempDir
 import java.net.URI
 import java.nio.file.Files
 import java.nio.file.Path
@@ -339,8 +340,10 @@ class OpenApiToGeneratedApiTest {
   }
 
   @Test
-  fun `rejects OpenAPI operations with multiple service group tags`() {
-    val source = Files.createTempFile("sunday-openapi-service-tags", ".yaml")
+  fun `rejects OpenAPI operations with multiple service group tags`(
+    @TempDir tempDir: Path,
+  ) {
+    val source = tempDir.resolve("sunday-openapi-service-tags.yaml")
     Files.writeString(
       source,
       """

--- a/generator/src/test/kotlin/io/outfoxx/sunday/generator/ir/OpenApiToGeneratedApiTest.kt
+++ b/generator/src/test/kotlin/io/outfoxx/sunday/generator/ir/OpenApiToGeneratedApiTest.kt
@@ -19,6 +19,7 @@ package io.outfoxx.sunday.generator.ir
 import io.outfoxx.sunday.test.extensions.ResourceExtension
 import io.outfoxx.sunday.test.extensions.ResourceUri
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import java.net.URI
@@ -205,7 +206,7 @@ class OpenApiToGeneratedApiTest {
   fun `maps OpenAPI JAX-RS REST client metadata from root and service tags`(
     @ResourceUri("openapi/ir/jaxrs-rest-client-3.1.yaml") testUri: URI,
   ) {
-    val api = OpenApiToGeneratedApi(GeneratedApiIrOptions(deriveServicesFromTags = true)).convert(testUri)
+    val api = OpenApiToGeneratedApi().convert(testUri)
 
     assertEquals(
       GeneratedJaxrs(restClient = GeneratedJaxrsRestClient(configKey = "platform")),
@@ -335,6 +336,44 @@ class OpenApiToGeneratedApiTest {
     val api = OpenApiToGeneratedApi().convert(testUri)
 
     assertEquals(expectedYaml("extensions-3.1.ir.yaml"), normalizedYaml(api))
+  }
+
+  @Test
+  fun `rejects OpenAPI operations with multiple service group tags`() {
+    val source = Files.createTempFile("sunday-openapi-service-tags", ".yaml")
+    Files.writeString(
+      source,
+      """
+      openapi: 3.1.0
+      info:
+        title: Tagged API
+        version: 1.0.0
+      tags:
+        - name: users
+          x-sunday-service-group: true
+        - name: audit
+          x-sunday-service-group: true
+      paths:
+        /users:
+          get:
+            tags: [users, audit]
+            operationId: listUsers
+            responses:
+              "204":
+                description: No content.
+      """.trimIndent(),
+    )
+
+    val error =
+      assertThrows(IllegalArgumentException::class.java) {
+        OpenApiToGeneratedApi().convert(source.toUri())
+      }
+
+    assertEquals(
+      "OpenAPI path '/users' operation has multiple service tags (users, audit). " +
+        "Add x-sunday-service to select one generated service explicitly.",
+      error.message,
+    )
   }
 
   private fun normalizedYaml(api: GeneratedApi): String =

--- a/generator/src/test/resources/ir/expected/OpenApiToGeneratedApiTest/extensions-3.1.ir.yaml
+++ b/generator/src/test/resources/ir/expected/OpenApiToGeneratedApiTest/extensions-3.1.ir.yaml
@@ -4,7 +4,7 @@ source:
   kind: "OPENAPI"
   location: "SOURCE_LOCATION"
 services:
-- name: "ExtensionsService"
+- name: "ProjectsService"
   baseUri: "https://api.example.com/{version}"
   baseUriParameters:
   - name: "version"
@@ -141,6 +141,7 @@ auth:
 media: {}
 tags:
 - name: "projects"
+  serviceGroup: true
   policy:
     timeout: "PT30S"
     retry:

--- a/generator/src/test/resources/openapi/ir/extensions-3.1.yaml
+++ b/generator/src/test/resources/openapi/ir/extensions-3.1.yaml
@@ -27,6 +27,7 @@ x-sunday-zanzibar:
 tags:
   - name: projects
     description: Project operations.
+    x-sunday-service-group: true
     x-sunday-policy:
       timeout: PT30S
       retry:

--- a/generator/src/test/resources/openapi/ir/jaxrs-rest-client-3.1.yaml
+++ b/generator/src/test/resources/openapi/ir/jaxrs-rest-client-3.1.yaml
@@ -9,6 +9,7 @@ servers:
   - url: http://localhost:9080
 tags:
   - name: Graphs
+    x-sunday-service-group: true
     x-sunday-jaxrs:
       rest-client:
         config-key: graphs


### PR DESCRIPTION
## Summary

Adds explicit OpenAPI tag service grouping via `x-sunday-service-group: true`.

## Details

- Adds `GeneratedTag.serviceGroup` and preserves it through YAML.
- Maps OpenAPI tag `x-sunday-service-group: true` into IR.
- Uses only explicit service-group tags for OpenAPI service derivation unless `-services-from-tags` is enabled.
- Keeps `-services-from-tags` as the broad convenience mode that treats all operation tags as service groups.
- Keeps `x-sunday-policy` and `x-sunday-jaxrs` as tag metadata without implying service grouping.
- Documents the new tag behavior in the IR format guide.

## Validation

- `./gradlew :generator:test --tests io.outfoxx.sunday.generator.ir.OpenApiToGeneratedApiTest --tests io.outfoxx.sunday.generator.ir.GeneratedApiYamlTest --rerun-tasks`
- `./gradlew :generator:ktlintCheck :generator:check`
- `git diff --check`
