### PR TITLE
Preserve Kotlin integer scalar widths

### DIFF
--- a/generator/src/main/kotlin/io/outfoxx/sunday/generator/kotlin/KotlinJAXRSIrGenerator.kt
+++ b/generator/src/main/kotlin/io/outfoxx/sunday/generator/kotlin/KotlinJAXRSIrGenerator.kt
@@ -125,6 +125,7 @@ import io.outfoxx.sunday.generator.kotlin.utils.ZALANDO_THROWABLE_PROBLEM
 import io.outfoxx.sunday.generator.kotlin.utils.addAnnotation
 import io.outfoxx.sunday.generator.kotlin.utils.addQuarkusHttpProblemAlias
 import io.outfoxx.sunday.generator.kotlin.utils.kotlinIdentifierName
+import io.outfoxx.sunday.generator.kotlin.utils.kotlinIntegerScalarTypeName
 import io.outfoxx.sunday.generator.kotlin.utils.kotlinTypeName
 import io.outfoxx.sunday.generator.kotlin.utils.rawType
 import io.outfoxx.sunday.generator.utils.equalsInAnyOrder
@@ -2602,7 +2603,7 @@ class KotlinJAXRSIrGenerator(
   }
 
   private fun GeneratedTypeRef.scalarTypeName(): TypeName =
-    formattedScalarTypeName() ?: when (name) {
+    kotlinIntegerScalarTypeName() ?: formattedScalarTypeName() ?: when (name) {
       "any" -> ANY
       "string" -> STRING
       "boolean" -> BOOLEAN

--- a/generator/src/main/kotlin/io/outfoxx/sunday/generator/kotlin/KotlinSundayIrGenerator.kt
+++ b/generator/src/main/kotlin/io/outfoxx/sunday/generator/kotlin/KotlinSundayIrGenerator.kt
@@ -123,6 +123,7 @@ import io.outfoxx.sunday.generator.kotlin.utils.ZALANDO_EXCEPTIONAL
 import io.outfoxx.sunday.generator.kotlin.utils.ZALANDO_STATUS
 import io.outfoxx.sunday.generator.kotlin.utils.ZALANDO_THROWABLE_PROBLEM
 import io.outfoxx.sunday.generator.kotlin.utils.kotlinIdentifierName
+import io.outfoxx.sunday.generator.kotlin.utils.kotlinIntegerScalarTypeName
 import io.outfoxx.sunday.generator.kotlin.utils.kotlinTypeName
 import io.outfoxx.sunday.generator.utils.toLowerCamelCase
 import io.outfoxx.sunday.generator.utils.toUpperCamelCase
@@ -1764,7 +1765,7 @@ class KotlinSundayIrGenerator(
   }
 
   private fun GeneratedTypeRef.scalarTypeName(): TypeName =
-    formattedScalarTypeName() ?: when (name) {
+    kotlinIntegerScalarTypeName() ?: formattedScalarTypeName() ?: when (name) {
       "any" -> ANY
       "string" -> STRING
       "boolean" -> BOOLEAN

--- a/generator/src/main/kotlin/io/outfoxx/sunday/generator/kotlin/utils/KotlinTypeRefs.kt
+++ b/generator/src/main/kotlin/io/outfoxx/sunday/generator/kotlin/utils/KotlinTypeRefs.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2020 Outfox, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.outfoxx.sunday.generator.kotlin.utils
+
+import com.squareup.kotlinpoet.BYTE
+import com.squareup.kotlinpoet.INT
+import com.squareup.kotlinpoet.LONG
+import com.squareup.kotlinpoet.SHORT
+import com.squareup.kotlinpoet.TypeName
+import io.outfoxx.sunday.generator.ir.GeneratedTypeRef
+
+fun GeneratedTypeRef.kotlinIntegerScalarTypeName(): TypeName? =
+  if (name == "integer") {
+    when (format?.lowercase()) {
+      "int8" -> BYTE
+      "int16" -> SHORT
+      "int", "int32" -> INT
+      "long", "int64" -> LONG
+      else -> null
+    }
+  } else {
+    null
+  }

--- a/generator/src/test/kotlin/io/outfoxx/sunday/generator/kotlin/jaxrs/KotlinJAXRSIrGeneratorTest.kt
+++ b/generator/src/test/kotlin/io/outfoxx/sunday/generator/kotlin/jaxrs/KotlinJAXRSIrGeneratorTest.kt
@@ -805,6 +805,24 @@ class KotlinJAXRSIrGeneratorTest {
     assertTrue(source.contains("public val startsAt: LocalTime"), source)
     assertTrue(source.contains("public val targetUrl: URI"), source)
     assertTrue(source.contains("public val id: UUID"), source)
+    assertTrue(source.contains("public val anyValue: Any"), source)
+    assertTrue(source.contains("public val title: String"), source)
+    assertTrue(source.contains("public val enabled: Boolean"), source)
+    assertTrue(source.contains("public val defaultCount: Int"), source)
+    assertTrue(source.contains("public val smallCount: Byte"), source)
+    assertTrue(source.contains("public val mediumCount: Short"), source)
+    assertTrue(source.contains("public val count: Int"), source)
+    assertTrue(source.contains("public val aliasCount: Int"), source)
+    assertTrue(source.contains("public val largeCount: Long"), source)
+    assertTrue(source.contains("public val aliasLargeCount: Long"), source)
+    assertTrue(source.contains("public val legacyCount: Int"), source)
+    assertTrue(source.contains("public val legacyLargeCount: Long"), source)
+    assertTrue(source.contains("public val directLongCount: Long"), source)
+    assertTrue(source.contains("public val ratio: Double"), source)
+    assertTrue(source.contains("public val preciseRatio: Double"), source)
+    assertTrue(source.contains("public val filePayload: ByteArray"), source)
+    assertTrue(source.contains("public val emptyValue: Unit"), source)
+    assertTrue(source.contains("public val unknownValue: String"), source)
   }
 
   @OptIn(ExperimentalCompilerApi::class)
@@ -2324,6 +2342,44 @@ class KotlinJAXRSIrGeneratorTest {
                 GeneratedModelProperty("startsAt", GeneratedTypeRef.scalar("string", format = "time"), required = true),
                 GeneratedModelProperty("targetUrl", GeneratedTypeRef.scalar("string", format = "uri"), required = true),
                 GeneratedModelProperty("id", GeneratedTypeRef.scalar("string", format = "uuid"), required = true),
+                GeneratedModelProperty("anyValue", GeneratedTypeRef.scalar("any"), required = true),
+                GeneratedModelProperty("title", GeneratedTypeRef.scalar("string"), required = true),
+                GeneratedModelProperty("enabled", GeneratedTypeRef.scalar("boolean"), required = true),
+                GeneratedModelProperty("defaultCount", GeneratedTypeRef.scalar("integer"), required = true),
+                GeneratedModelProperty(
+                  "smallCount",
+                  GeneratedTypeRef.scalar("integer", format = "int8"),
+                  required = true,
+                ),
+                GeneratedModelProperty(
+                  "mediumCount",
+                  GeneratedTypeRef.scalar("integer", format = "int16"),
+                  required = true,
+                ),
+                GeneratedModelProperty("count", GeneratedTypeRef.scalar("integer", format = "int32"), required = true),
+                GeneratedModelProperty(
+                  "aliasCount",
+                  GeneratedTypeRef.scalar("integer", format = "int"),
+                  required = true,
+                ),
+                GeneratedModelProperty(
+                  "largeCount",
+                  GeneratedTypeRef.scalar("integer", format = "int64"),
+                  required = true,
+                ),
+                GeneratedModelProperty(
+                  "aliasLargeCount",
+                  GeneratedTypeRef.scalar("integer", format = "long"),
+                  required = true,
+                ),
+                GeneratedModelProperty("legacyCount", GeneratedTypeRef.scalar("int32"), required = true),
+                GeneratedModelProperty("legacyLargeCount", GeneratedTypeRef.scalar("int64"), required = true),
+                GeneratedModelProperty("directLongCount", GeneratedTypeRef.scalar("long"), required = true),
+                GeneratedModelProperty("ratio", GeneratedTypeRef.scalar("number"), required = true),
+                GeneratedModelProperty("preciseRatio", GeneratedTypeRef.scalar("double"), required = true),
+                GeneratedModelProperty("filePayload", GeneratedTypeRef.scalar("file"), required = true),
+                GeneratedModelProperty("emptyValue", GeneratedTypeRef.scalar("nil"), required = true),
+                GeneratedModelProperty("unknownValue", GeneratedTypeRef.scalar("unknown"), required = true),
               ),
           ),
         ),

--- a/generator/src/test/kotlin/io/outfoxx/sunday/generator/kotlin/sunday/KotlinSundayIrGeneratorTest.kt
+++ b/generator/src/test/kotlin/io/outfoxx/sunday/generator/kotlin/sunday/KotlinSundayIrGeneratorTest.kt
@@ -1246,6 +1246,96 @@ class KotlinSundayIrGeneratorTest {
                     type = GeneratedTypeRef.scalar("string", format = "binary"),
                     required = true,
                   ),
+                  GeneratedModelProperty(
+                    name = "anyValue",
+                    type = GeneratedTypeRef.scalar("any"),
+                    required = true,
+                  ),
+                  GeneratedModelProperty(
+                    name = "title",
+                    type = GeneratedTypeRef.scalar("string"),
+                    required = true,
+                  ),
+                  GeneratedModelProperty(
+                    name = "enabled",
+                    type = GeneratedTypeRef.scalar("boolean"),
+                    required = true,
+                  ),
+                  GeneratedModelProperty(
+                    name = "defaultCount",
+                    type = GeneratedTypeRef.scalar("integer"),
+                    required = true,
+                  ),
+                  GeneratedModelProperty(
+                    name = "smallCount",
+                    type = GeneratedTypeRef.scalar("integer", format = "int8"),
+                    required = true,
+                  ),
+                  GeneratedModelProperty(
+                    name = "mediumCount",
+                    type = GeneratedTypeRef.scalar("integer", format = "int16"),
+                    required = true,
+                  ),
+                  GeneratedModelProperty(
+                    name = "count",
+                    type = GeneratedTypeRef.scalar("integer", format = "int32"),
+                    required = true,
+                  ),
+                  GeneratedModelProperty(
+                    name = "aliasCount",
+                    type = GeneratedTypeRef.scalar("integer", format = "int"),
+                    required = true,
+                  ),
+                  GeneratedModelProperty(
+                    name = "largeCount",
+                    type = GeneratedTypeRef.scalar("integer", format = "int64"),
+                    required = true,
+                  ),
+                  GeneratedModelProperty(
+                    name = "aliasLargeCount",
+                    type = GeneratedTypeRef.scalar("integer", format = "long"),
+                    required = true,
+                  ),
+                  GeneratedModelProperty(
+                    name = "legacyCount",
+                    type = GeneratedTypeRef.scalar("int32"),
+                    required = true,
+                  ),
+                  GeneratedModelProperty(
+                    name = "legacyLargeCount",
+                    type = GeneratedTypeRef.scalar("int64"),
+                    required = true,
+                  ),
+                  GeneratedModelProperty(
+                    name = "directLongCount",
+                    type = GeneratedTypeRef.scalar("long"),
+                    required = true,
+                  ),
+                  GeneratedModelProperty(
+                    name = "ratio",
+                    type = GeneratedTypeRef.scalar("number"),
+                    required = true,
+                  ),
+                  GeneratedModelProperty(
+                    name = "preciseRatio",
+                    type = GeneratedTypeRef.scalar("double"),
+                    required = true,
+                  ),
+                  GeneratedModelProperty(
+                    name = "filePayload",
+                    type = GeneratedTypeRef.scalar("file"),
+                    required = true,
+                  ),
+                  GeneratedModelProperty(
+                    name = "emptyValue",
+                    type = GeneratedTypeRef.scalar("nil"),
+                    required = true,
+                  ),
+                  GeneratedModelProperty(
+                    name = "unknownValue",
+                    type = GeneratedTypeRef.scalar("unknown"),
+                    required = true,
+                  ),
                 ),
             ),
           ),
@@ -1271,6 +1361,24 @@ class KotlinSundayIrGeneratorTest {
     assertContains(source, "public val `requestId`: UUID")
     assertContains(source, "public val `callbackUrl`: URI")
     assertContains(source, "public val `payload`: ByteArray")
+    assertContains(source, "public val `anyValue`: Any")
+    assertContains(source, "public val `title`: String")
+    assertContains(source, "public val `enabled`: Boolean")
+    assertContains(source, "public val `defaultCount`: Int")
+    assertContains(source, "public val `smallCount`: Byte")
+    assertContains(source, "public val `mediumCount`: Short")
+    assertContains(source, "public val `count`: Int")
+    assertContains(source, "public val `aliasCount`: Int")
+    assertContains(source, "public val `largeCount`: Long")
+    assertContains(source, "public val `aliasLargeCount`: Long")
+    assertContains(source, "public val `legacyCount`: Int")
+    assertContains(source, "public val `legacyLargeCount`: Long")
+    assertContains(source, "public val `directLongCount`: Long")
+    assertContains(source, "public val `ratio`: Double")
+    assertContains(source, "public val `preciseRatio`: Double")
+    assertContains(source, "public val `filePayload`: ByteArray")
+    assertContains(source, "public val `emptyValue`: Unit")
+    assertContains(source, "public val `unknownValue`: String")
   }
 
   @OptIn(ExperimentalCompilerApi::class)

--- a/generator/src/test/kotlin/io/outfoxx/sunday/generator/kotlin/utils/KotlinTypeRefsTest.kt
+++ b/generator/src/test/kotlin/io/outfoxx/sunday/generator/kotlin/utils/KotlinTypeRefsTest.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2020 Outfox, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.outfoxx.sunday.generator.kotlin.utils
+
+import com.squareup.kotlinpoet.BYTE
+import com.squareup.kotlinpoet.INT
+import com.squareup.kotlinpoet.LONG
+import com.squareup.kotlinpoet.SHORT
+import io.outfoxx.sunday.generator.ir.GeneratedTypeRef
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+class KotlinTypeRefsTest {
+
+  @Test
+  fun `maps integer scalar formats to Kotlin width types`() {
+    assertEquals(BYTE, GeneratedTypeRef.scalar("integer", format = "int8").kotlinIntegerScalarTypeName())
+    assertEquals(SHORT, GeneratedTypeRef.scalar("integer", format = "int16").kotlinIntegerScalarTypeName())
+    assertEquals(INT, GeneratedTypeRef.scalar("integer", format = "int").kotlinIntegerScalarTypeName())
+    assertEquals(INT, GeneratedTypeRef.scalar("integer", format = "int32").kotlinIntegerScalarTypeName())
+    assertEquals(LONG, GeneratedTypeRef.scalar("integer", format = "long").kotlinIntegerScalarTypeName())
+    assertEquals(LONG, GeneratedTypeRef.scalar("integer", format = "int64").kotlinIntegerScalarTypeName())
+  }
+
+  @Test
+  fun `returns null for non width integer formats`() {
+    assertNull(GeneratedTypeRef.scalar("integer").kotlinIntegerScalarTypeName())
+    assertNull(GeneratedTypeRef.scalar("integer", format = "").kotlinIntegerScalarTypeName())
+    assertNull(GeneratedTypeRef.scalar("integer", format = "decimal").kotlinIntegerScalarTypeName())
+  }
+
+  @Test
+  fun `returns null for non integer scalars`() {
+    assertNull(GeneratedTypeRef.scalar("string", format = "int64").kotlinIntegerScalarTypeName())
+    assertNull(GeneratedTypeRef.scalar("long").kotlinIntegerScalarTypeName())
+  }
+}


### PR DESCRIPTION
Summary
- Preserve OpenAPI/AsyncAPI integer format widths when rendering Kotlin scalar types.
- Map integer formats int8/int16/int32/int64 to Byte/Short/Int/Long in Kotlin/Sunday and Kotlin/JAX-RS.

Details
- Adds a Kotlin integer format resolver before the generic formatted scalar resolver.
- Extends existing compile-backed scalar format tests to cover integer width formats.

Validation
- ./gradlew :generator:test --tests io.outfoxx.sunday.generator.kotlin.sunday.KotlinSundayIrGeneratorTest --tests io.outfoxx.sunday.generator.kotlin.jaxrs.KotlinJAXRSIrGeneratorTest --rerun-tasks
- ./gradlew :generator:ktlintCheck --rerun-tasks
- ./gradlew :generator:check