### PR TITLE
Generate Python streaming request operations

### DIFF
--- a/generator/src/main/kotlin/io/outfoxx/sunday/generator/python/PythonClientRenderer.kt
+++ b/generator/src/main/kotlin/io/outfoxx/sunday/generator/python/PythonClientRenderer.kt
@@ -16,12 +16,14 @@
 
 package io.outfoxx.sunday.generator.python
 
+import io.outfoxx.sunday.generator.GenerationMode
 import io.outfoxx.sunday.generator.ir.GeneratedOperation
 import io.outfoxx.sunday.generator.ir.GeneratedParameter
 import io.outfoxx.sunday.generator.ir.GeneratedPayload
 import io.outfoxx.sunday.generator.ir.GeneratedResponse
 import io.outfoxx.sunday.generator.ir.GeneratedService
 import io.outfoxx.sunday.generator.ir.GeneratedTypeRef
+import io.outfoxx.sunday.generator.ir.emit.enabledFor
 
 /** Renders the first Python client runtime and service method surface from IR. */
 class PythonClientRenderer(
@@ -37,6 +39,8 @@ class PythonClientRenderer(
     module.addExport("EventStream")
     module.addExport("MediaType")
     module.addExport("ResponseHeaders")
+    module.addExport("StreamingBody")
+    module.addExport("StreamingOperation")
     module.addExport("Transport")
     module.addExport("TransportRequest")
     module.addExport("TransportResponse")
@@ -49,6 +53,49 @@ class PythonClientRenderer(
         type Transport = %T
         type TransportRequest = %T
         type TransportResponse = %T
+        type StreamingBodyChunk = bytes | bytearray | memoryview
+        type StreamingBodyContent = bytes | %T[bytes] | %T[bytes]
+
+
+        def _streaming_chunk(chunk: StreamingBodyChunk) -> bytes:
+            return bytes(chunk)
+
+
+        def _streaming_iterable(chunks: %T[StreamingBodyChunk]) -> %T[bytes]:
+            for chunk in chunks:
+                yield _streaming_chunk(chunk)
+
+
+        async def _streaming_async_iterable(chunks: %T[StreamingBodyChunk]) -> %T[bytes]:
+            async for chunk in chunks:
+                yield _streaming_chunk(chunk)
+
+
+        @%T(frozen=True, slots=True)
+        class StreamingBody:
+            ${"\"\"\"A reusable streaming request body backed by a fresh content factory.\"\"\""}
+
+            factory: %T[[], StreamingBodyContent]
+
+            @classmethod
+            def bytes(cls, data: StreamingBodyChunk) -> StreamingBody:
+                ${"\"\"\"Create a streaming body from in-memory bytes.\"\"\""}
+                content = _streaming_chunk(data)
+                return cls(lambda: content)
+
+            @classmethod
+            def iterable(cls, factory: %T[[], %T[StreamingBodyChunk]]) -> StreamingBody:
+                ${"\"\"\"Create a streaming body from a fresh byte iterable factory.\"\"\""}
+                return cls(lambda: _streaming_iterable(factory()))
+
+            @classmethod
+            def async_iterable(cls, factory: %T[[], %T[StreamingBodyChunk]]) -> StreamingBody:
+                ${"\"\"\"Create a streaming body from a fresh async byte iterable factory.\"\"\""}
+                return cls(lambda: _streaming_async_iterable(factory()))
+
+            def content(self) -> StreamingBodyContent:
+                ${"\"\"\"Create the httpx request content for one request attempt.\"\"\""}
+                return self.factory()
 
 
         @%T(frozen=True, slots=True)
@@ -158,6 +205,33 @@ class PythonClientRenderer(
 
 
         @%T(frozen=True, slots=True)
+        class StreamingOperation[ResponseT]:
+            ${"\"\"\"A prepared streaming upload operation that builds a fresh request for each attempt.\"\"\""}
+
+            transport: Transport
+            build_request: %T[[], TransportRequest]
+            decode: %T[[%T], ResponseT]
+
+            async def execute(self) -> ResponseT:
+                ${"\"\"\"Send the request and decode the successful response body.\"\"\""}
+                return (await self.response()).result
+
+            async def response(self) -> OperationResponse[ResponseT]:
+                ${"\"\"\"Send the request and return the decoded response with metadata.\"\"\""}
+                response = await self.transport_response()
+                response.raise_for_status()
+                return OperationResponse(result=self.decode(response), transport_response=response)
+
+            def transport_request(self) -> TransportRequest:
+                ${"\"\"\"Return a fresh transport-specific request value.\"\"\""}
+                return self.build_request()
+
+            async def transport_response(self) -> TransportResponse:
+                ${"\"\"\"Send a fresh request and return the transport-specific response value.\"\"\""}
+                return await self.transport.send(self.build_request())
+
+
+        @%T(frozen=True, slots=True)
         class EventStream[EventT]:
             ${"\"\"\"A prepared HTTP SSE stream that decodes events as they arrive.\"\"\""}
 
@@ -226,11 +300,27 @@ class PythonClientRenderer(
         PythonSymbol("httpx", "AsyncClient"),
         PythonSymbol("httpx", "Request"),
         PythonSymbol("httpx", "Response"),
+        PythonSymbol("collections.abc", "Iterable"),
+        PythonSymbol("collections.abc", "AsyncIterable"),
+        PythonSymbol("collections.abc", "Iterable"),
+        PythonSymbol("collections.abc", "Iterator"),
+        PythonSymbol("collections.abc", "AsyncIterable"),
+        PythonSymbol("collections.abc", "AsyncIterator"),
+        PythonSymbol("dataclasses", "dataclass"),
+        PythonSymbol("collections.abc", "Callable"),
+        PythonSymbol("collections.abc", "Callable"),
+        PythonSymbol("collections.abc", "Iterable"),
+        PythonSymbol("collections.abc", "Callable"),
+        PythonSymbol("collections.abc", "AsyncIterable"),
         PythonSymbol("dataclasses", "dataclass"),
         PythonSymbol("dataclasses", "dataclass"),
         PythonSymbol("httpx", "Headers"),
         PythonSymbol("dataclasses", "dataclass"),
         PythonSymbol("dataclasses", "dataclass"),
+        PythonSymbol("collections.abc", "Callable"),
+        PythonSymbol("httpx", "Response"),
+        PythonSymbol("dataclasses", "dataclass"),
+        PythonSymbol("collections.abc", "Callable"),
         PythonSymbol("collections.abc", "Callable"),
         PythonSymbol("httpx", "Response"),
         PythonSymbol("dataclasses", "dataclass"),
@@ -297,6 +387,12 @@ class PythonClientRenderer(
     val responseType = response?.type ?: GeneratedTypeRef.scalar("nil")
     val decoderName = "_decode_${id.pythonIdentifierName}_response"
     val signatureParameters = renderClientSignatureParameterLines()
+    val operationType =
+      if (requestBody.isPythonStreamingRequestBody) {
+        PythonSymbol(".runtime", "StreamingOperation")
+      } else {
+        PythonSymbol(".runtime", "Operation")
+      }
 
     return if (hasClientSignatureParameters()) {
       PythonCodeBlock.of(
@@ -311,11 +407,15 @@ class PythonClientRenderer(
         """.trimMargin(),
         id.pythonIdentifierName,
         signatureParameters,
-        PythonSymbol(".runtime", "Operation"),
+        operationType,
         responseType.renderClientPythonType(),
         id,
-        renderBuildRequest(),
-        renderOperationReturn(PythonSymbol(".runtime", "Operation"), decoderName),
+        if (requestBody.isPythonStreamingRequestBody) {
+          renderBuildStreamingRequestFunction()
+        } else {
+          renderBuildRequest()
+        },
+        renderOperationReturn(operationType, decoderName, requestBody.isPythonStreamingRequestBody),
       )
     } else {
       PythonCodeBlock.of(
@@ -326,11 +426,15 @@ class PythonClientRenderer(
         |%C
         """.trimMargin(),
         id.pythonIdentifierName,
-        PythonSymbol(".runtime", "Operation"),
+        operationType,
         responseType.renderClientPythonType(),
         id,
-        renderBuildRequest(),
-        renderOperationReturn(PythonSymbol(".runtime", "Operation"), decoderName),
+        if (requestBody.isPythonStreamingRequestBody) {
+          renderBuildStreamingRequestFunction()
+        } else {
+          renderBuildRequest()
+        },
+        renderOperationReturn(operationType, decoderName, requestBody.isPythonStreamingRequestBody),
       )
     }
   }
@@ -357,7 +461,7 @@ class PythonClientRenderer(
         responseType.renderClientPythonType(),
         id,
         renderBuildRequest(),
-        renderOperationReturn(PythonSymbol(".runtime", "EventStream"), decoderName),
+        renderOperationReturn(PythonSymbol(".runtime", "EventStream"), decoderName, false),
       )
     } else {
       PythonCodeBlock.of(
@@ -372,7 +476,7 @@ class PythonClientRenderer(
         responseType.renderClientPythonType(),
         id,
         renderBuildRequest(),
-        renderOperationReturn(PythonSymbol(".runtime", "EventStream"), decoderName),
+        renderOperationReturn(PythonSymbol(".runtime", "EventStream"), decoderName, false),
       )
     }
   }
@@ -386,24 +490,58 @@ class PythonClientRenderer(
       |        )
       """.trimMargin(),
       httpMethod(),
-      renderPathTemplateArgument(),
-      renderBuildRequestArguments(),
+      renderPathTemplateArgument("            "),
+      renderBuildRequestArguments("            "),
+    )
+
+  private fun GeneratedOperation.renderBuildStreamingRequestFunction(): PythonCodeBlock =
+    PythonCodeBlock.of(
+      """
+      |
+      |        def build_request() -> %T:
+      |            return self._transport.build_request(
+      |                %S,
+      |%C%C
+      |            )
+      |
+      """.trimMargin(),
+      PythonSymbol(".runtime", "TransportRequest"),
+      httpMethod(),
+      renderPathTemplateArgument("                "),
+      renderBuildRequestArguments("                "),
     )
 
   private fun GeneratedOperation.renderOperationReturn(
     operationType: PythonSymbol,
     decoderName: String,
+    streamingRequestBody: Boolean,
   ): PythonCodeBlock =
     PythonCodeBlock.of(
       """
       |        return %T(
-      |            transport=self._transport,
-      |            request=request,
-      |            decode=%L,
+      |%C
       |        )
       """.trimMargin(),
       operationType,
-      decoderName,
+      if (streamingRequestBody) {
+        PythonCodeBlock.of(
+          """
+          |            transport=self._transport,
+          |            build_request=build_request,
+          |            decode=%L,
+          """.trimMargin(),
+          decoderName,
+        )
+      } else {
+        PythonCodeBlock.of(
+          """
+          |            transport=self._transport,
+          |            request=request,
+          |            decode=%L,
+          """.trimMargin(),
+          decoderName,
+        )
+      },
     )
 
   private fun GeneratedOperation.hasClientSignatureParameters(): Boolean =
@@ -482,7 +620,11 @@ class PythonClientRenderer(
   }
 
   private fun GeneratedPayload.renderRequestBodyParameter(): PythonCodeBlock =
-    PythonCodeBlock.of("        body: %C,", type.renderClientPythonType(nullable = false))
+    if (isPythonStreamingRequestBody) {
+      PythonCodeBlock.of("        body: %T,", PythonSymbol(".runtime", "StreamingBody"))
+    } else {
+      PythonCodeBlock.of("        body: %C,", type.renderClientPythonType(nullable = false))
+    }
 
   private fun GeneratedParameter.renderOptionalParameter(): PythonCodeBlock =
     PythonCodeBlock.of(
@@ -510,13 +652,14 @@ class PythonClientRenderer(
       else -> PythonCodeBlock.of("None")
     }
 
-  private fun GeneratedOperation.renderPathTemplateArgument(): PythonCodeBlock {
+  private fun GeneratedOperation.renderPathTemplateArgument(indent: String): PythonCodeBlock {
     val pathParameters = pathParameters()
     val inlineMap = pathParameters.renderInlinePathParameterMap()
     val inlineCall = "path_template(${path.pythonStringLiteral()}, $inlineMap),"
     return if (inlineCall.length <= 100) {
       PythonCodeBlock.of(
-        "            %T(%S, %L),",
+        "%L%T(%S, %L),",
+        indent,
         PythonSymbol(".runtime", "path_template"),
         path,
         inlineMap,
@@ -524,14 +667,17 @@ class PythonClientRenderer(
     } else {
       PythonCodeBlock.of(
         """
-        |            %T(
-        |                %S,
+        |%L%T(
+        |%L    %S,
         |%C
-        |            ),
+        |%L),
         """.trimMargin(),
+        indent,
         PythonSymbol(".runtime", "path_template"),
+        indent,
         path,
-        pathParameters.renderMultilinePathParameterMap(),
+        pathParameters.renderMultilinePathParameterMap(indent),
+        indent,
       )
     }
   }
@@ -545,29 +691,30 @@ class PythonClientRenderer(
       }
     }
 
-  private fun List<GeneratedParameter>.renderMultilinePathParameterMap(): PythonCodeBlock =
+  private fun List<GeneratedParameter>.renderMultilinePathParameterMap(indent: String): PythonCodeBlock =
     if (isEmpty()) {
-      PythonCodeBlock.of("                {},")
+      PythonCodeBlock.of("%L    {},", indent)
     } else {
       PythonCodeBlock.join(
-        listOf(PythonCodeBlock.of("                {")) +
+        listOf(PythonCodeBlock.of("%L    {", indent)) +
           map { parameter ->
             PythonCodeBlock.of(
-              "                    %S: %L,",
+              "%L        %S: %L,",
+              indent,
               parameter.wireName(),
               parameter.name.pythonIdentifierName,
             )
           } +
-          listOf(PythonCodeBlock.of("                },")),
+          listOf(PythonCodeBlock.of("%L    },", indent)),
       )
     }
 
-  private fun GeneratedOperation.renderBuildRequestArguments(): PythonCodeBlock {
+  private fun GeneratedOperation.renderBuildRequestArguments(indent: String): PythonCodeBlock {
     val arguments =
       listOfNotNull(
-        queryParameters().renderRequestParameters("params"),
-        headerParameters().renderRequestParameters("headers"),
-        requestBody?.renderRequestBodyArgument(),
+        queryParameters().renderRequestParameters("params", indent),
+        renderHeadersArgument(indent),
+        requestBody?.renderRequestBodyArgument(indent),
       )
 
     return if (arguments.isEmpty()) {
@@ -577,24 +724,63 @@ class PythonClientRenderer(
     }
   }
 
-  private fun GeneratedPayload.renderRequestBodyArgument(): PythonCodeBlock =
-    if (type.isBinaryPayload()) {
-      PythonCodeBlock.of("            content=body,")
-    } else {
-      PythonCodeBlock.of("            json=%T(body),", PythonSymbol(".runtime", "json_body"))
+  private fun GeneratedOperation.renderHeadersArgument(indent: String): PythonCodeBlock? {
+    val headerParameters = headerParameters()
+    val contentType =
+      if (headerParameters.any { parameter -> parameter.wireName().equals("Content-Type", ignoreCase = true) }) {
+        null
+      } else {
+        requestBody.contentTypeHeaderForContentBody()
+      }
+
+    if (headerParameters.isEmpty() && contentType == null) {
+      return null
+    }
+
+    return PythonCodeBlock.of(
+      "%Lheaders=%C,",
+      indent,
+      when {
+        headerParameters.isEmpty() ->
+          PythonCodeBlock.of("{%S: %S}", "Content-Type", contentType)
+        contentType == null ->
+          headerParameters.renderRequestParameterMap()
+        else ->
+          PythonCodeBlock.of(
+            "{**%C, %S: %S}",
+            headerParameters.renderRequestParameterMap(),
+            "Content-Type",
+            contentType,
+          )
+      },
+    )
+  }
+
+  private fun GeneratedPayload.renderRequestBodyArgument(indent: String): PythonCodeBlock =
+    when {
+      isPythonStreamingRequestBody ->
+        PythonCodeBlock.of("%Lcontent=body.content(),", indent)
+      type.isBinaryPayload() ->
+        PythonCodeBlock.of("%Lcontent=body,", indent)
+      else ->
+        PythonCodeBlock.of("%Ljson=%T(body),", indent, PythonSymbol(".runtime", "json_body"))
     }
 
   private fun GeneratedTypeRef.isBinaryPayload(): Boolean =
     kind == GeneratedTypeRef.Kind.SCALAR &&
       (name == "file" || name == "binary" || name == "byte")
 
-  private fun List<GeneratedParameter>.renderRequestParameters(argumentName: String): PythonCodeBlock? {
+  private fun List<GeneratedParameter>.renderRequestParameters(
+    argumentName: String,
+    indent: String,
+  ): PythonCodeBlock? {
     if (isEmpty()) {
       return null
     }
 
     return PythonCodeBlock.of(
-      "            %L=%T({%L}),",
+      "%L%L=%T({%L}),",
+      indent,
       argumentName,
       PythonSymbol(".runtime", "parameter_map"),
       joinToString(", ") { parameter ->
@@ -602,6 +788,26 @@ class PythonClientRenderer(
       },
     )
   }
+
+  private fun List<GeneratedParameter>.renderRequestParameterMap(): PythonCodeBlock =
+    PythonCodeBlock.of(
+      "%T({%L})",
+      PythonSymbol(".runtime", "parameter_map"),
+      joinToString(", ") { parameter ->
+        "${parameter.wireName().pythonStringLiteral()}: ${parameter.name.pythonIdentifierName}"
+      },
+    )
+
+  private fun GeneratedPayload?.contentTypeHeaderForContentBody(): String? {
+    if (this == null || mediaTypes.isEmpty() || !usesPythonContentRequestBody) {
+      return null
+    }
+
+    return mediaTypes.first()
+  }
+
+  private val GeneratedPayload.usesPythonContentRequestBody: Boolean
+    get() = isPythonStreamingRequestBody || type.isBinaryPayload()
 
   private fun GeneratedOperation.pathParameters(): List<GeneratedParameter> =
     parameters.filter { parameter -> parameter.location == GeneratedParameter.Location.PATH }
@@ -674,4 +880,7 @@ class PythonClientRenderer(
           renderClientPythonType(nullable = false),
         )
     }
+
+  private val GeneratedPayload?.isPythonStreamingRequestBody: Boolean
+    get() = this?.streaming?.enabledFor(GenerationMode.Client) == true
 }

--- a/generator/src/test/kotlin/io/outfoxx/sunday/generator/python/PythonClientRendererTest.kt
+++ b/generator/src/test/kotlin/io/outfoxx/sunday/generator/python/PythonClientRendererTest.kt
@@ -16,6 +16,7 @@
 
 package io.outfoxx.sunday.generator.python
 
+import io.outfoxx.sunday.generator.ir.GeneratedModeFlag
 import io.outfoxx.sunday.generator.ir.GeneratedModel
 import io.outfoxx.sunday.generator.ir.GeneratedModelProperty
 import io.outfoxx.sunday.generator.ir.GeneratedOperation
@@ -229,6 +230,34 @@ class PythonClientRendererTest : PythonTest() {
                   ),
               ),
               GeneratedOperation(
+                id = "importProjectArchive",
+                method = "POST",
+                path = "/projects/{projectId}/archive",
+                parameters =
+                  listOf(
+                    GeneratedParameter(
+                      name = "projectId",
+                      location = GeneratedParameter.Location.PATH,
+                      type = GeneratedTypeRef.scalar("string"),
+                      required = true,
+                    ),
+                  ),
+                requestBody =
+                  GeneratedPayload(
+                    type = GeneratedTypeRef.scalar("file"),
+                    mediaTypes = listOf("application/x-tar"),
+                    streaming = GeneratedModeFlag(client = true),
+                  ),
+                responses =
+                  listOf(
+                    GeneratedResponse(
+                      status = 200,
+                      type = GeneratedTypeRef.named("UniqueId"),
+                      mediaTypes = listOf("application/json"),
+                    ),
+                  ),
+              ),
+              GeneratedOperation(
                 id = "createProjectRevision",
                 method = "POST",
                 path = "/projects/{projectId}/revisions",
@@ -292,6 +321,7 @@ class PythonClientRendererTest : PythonTest() {
           from turnpost_api.events import EventsClient
           from turnpost_api.models import ProjectCreatedData, UpdateProjectRequest
           from turnpost_api.projects import ProjectsClient
+          from turnpost_api.runtime import StreamingBody
 
 
           class EventByteStream(httpx.AsyncByteStream):
@@ -319,6 +349,12 @@ class PythonClientRendererTest : PythonTest() {
                   assert request.headers["Content-Type"] == "image/png"
                   assert request.content == b"avatar-bytes"
                   return httpx.Response(204)
+
+              if request.url.path == "/projects/project-1/archive":
+                  assert request.method == "POST"
+                  assert request.headers["Content-Type"] == "application/x-tar"
+                  assert request.content == b"archive-bytes"
+                  return httpx.Response(200, json="import-1")
 
               if request.url.path == "/projects/project-1/revisions":
                   assert request.method == "POST"
@@ -374,6 +410,17 @@ class PythonClientRendererTest : PythonTest() {
                       content_type="image/png",
                   ).execute()
                   assert avatar is None
+
+                  import_operation = ProjectsClient(http_client).import_project_archive(
+                      "project-1",
+                      StreamingBody.bytes(b"archive-bytes"),
+                  )
+                  import_request = import_operation.transport_request()
+                  assert import_request.method == "POST"
+                  assert import_request.url.path == "/projects/project-1/archive"
+
+                  import_id = await import_operation.execute()
+                  assert import_id == "import-1"
 
                   revision_id = await ProjectsClient(http_client).create_project_revision("project-1").execute()
                   assert revision_id == "revision-1"

--- a/generator/src/test/kotlin/io/outfoxx/sunday/generator/python/PythonGeneratedOutputParityTest.kt
+++ b/generator/src/test/kotlin/io/outfoxx/sunday/generator/python/PythonGeneratedOutputParityTest.kt
@@ -105,6 +105,29 @@ class PythonGeneratedOutputParityTest : PythonTest() {
   }
 
   @Test
+  fun `OpenAPI streaming request bodies emit Python streaming operations`(
+    compiler: PythonCompiler,
+    @ResourceUri("openapi/ir/streaming-request-3.1.yaml") sourceUri: URI,
+  ) {
+    val api = GeneratedApiIrExporter().export(sourceUri)
+    val modules = api.httpxModules()
+
+    assertTrue(
+      compileModules(
+        compiler,
+        modules,
+        importModules = modules.importModuleNames(),
+      ),
+    )
+    val clientSource = CompiledGeneratedSources.source(GeneratedCodeLanguage.Python, "parity_api/streaming_request.py")
+
+    assertTrue(clientSource.contains("body: StreamingBody"), clientSource)
+    assertTrue(clientSource.contains("-> StreamingOperation[ImportAccepted]"), clientSource)
+    assertTrue(clientSource.contains("build_request=build_request"), clientSource)
+    assertTrue(clientSource.contains("content=body.content()"), clientSource)
+  }
+
+  @Test
   fun `AsyncAPI source emits compile-backed client and server snapshots`(
     compiler: PythonCompiler,
     @ResourceUri("asyncapi/ir/typed-event-envelope-3.1.yaml") sourceUri: URI,

--- a/generator/src/test/resources/python/expected/PythonClientRendererTest/projects.py
+++ b/generator/src/test/resources/python/expected/PythonClientRendererTest/projects.py
@@ -1,7 +1,16 @@
 from __future__ import annotations
 
 from .models import ProjectView, UniqueId, UpdateProjectRequest
-from .runtime import Operation, Transport, json_body, parameter_map, path_template
+from .runtime import (
+    Operation,
+    StreamingBody,
+    StreamingOperation,
+    Transport,
+    TransportRequest,
+    json_body,
+    parameter_map,
+    path_template,
+)
 from httpx import Response
 from pydantic import TypeAdapter
 
@@ -81,6 +90,27 @@ class ProjectsClient:
             decode=_decode_put_project_avatar_response,
         )
 
+    def import_project_archive(
+        self,
+        project_id: str,
+        body: StreamingBody,
+    ) -> StreamingOperation[UniqueId]:
+        """Create the importProjectArchive operation."""
+
+        def build_request() -> TransportRequest:
+            return self._transport.build_request(
+                "POST",
+                path_template("/projects/{projectId}/archive", {"projectId": project_id}),
+                headers={"Content-Type": "application/x-tar"},
+                content=body.content(),
+            )
+
+        return StreamingOperation(
+            transport=self._transport,
+            build_request=build_request,
+            decode=_decode_import_project_archive_response,
+        )
+
     def create_project_revision(
         self,
         project_id: str,
@@ -111,6 +141,10 @@ def _decode_update_project_response(response: Response) -> ProjectView:
 
 def _decode_put_project_avatar_response(response: Response) -> None:
     return None
+
+
+def _decode_import_project_archive_response(response: Response) -> UniqueId:
+    return TypeAdapter(UniqueId).validate_python(response.json())
 
 
 def _decode_create_project_revision_response(response: Response) -> UniqueId:

--- a/generator/src/test/resources/python/expected/PythonClientRendererTest/runtime.py
+++ b/generator/src/test/resources/python/expected/PythonClientRendererTest/runtime.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import AsyncIterator, Callable, Mapping
+from collections.abc import AsyncIterable, AsyncIterator, Callable, Iterable, Iterator, Mapping
 from dataclasses import dataclass
 from httpx import AsyncClient, Headers, Request, Response
 from pydantic import BaseModel
@@ -12,6 +12,8 @@ __all__ = [
     "EventStream",
     "MediaType",
     "ResponseHeaders",
+    "StreamingBody",
+    "StreamingOperation",
     "Transport",
     "TransportRequest",
     "TransportResponse",
@@ -24,6 +26,49 @@ __all__ = [
 type Transport = AsyncClient
 type TransportRequest = Request
 type TransportResponse = Response
+type StreamingBodyChunk = bytes | bytearray | memoryview
+type StreamingBodyContent = bytes | Iterable[bytes] | AsyncIterable[bytes]
+
+
+def _streaming_chunk(chunk: StreamingBodyChunk) -> bytes:
+    return bytes(chunk)
+
+
+def _streaming_iterable(chunks: Iterable[StreamingBodyChunk]) -> Iterator[bytes]:
+    for chunk in chunks:
+        yield _streaming_chunk(chunk)
+
+
+async def _streaming_async_iterable(chunks: AsyncIterable[StreamingBodyChunk]) -> AsyncIterator[bytes]:
+    async for chunk in chunks:
+        yield _streaming_chunk(chunk)
+
+
+@dataclass(frozen=True, slots=True)
+class StreamingBody:
+    """A reusable streaming request body backed by a fresh content factory."""
+
+    factory: Callable[[], StreamingBodyContent]
+
+    @classmethod
+    def bytes(cls, data: StreamingBodyChunk) -> StreamingBody:
+        """Create a streaming body from in-memory bytes."""
+        content = _streaming_chunk(data)
+        return cls(lambda: content)
+
+    @classmethod
+    def iterable(cls, factory: Callable[[], Iterable[StreamingBodyChunk]]) -> StreamingBody:
+        """Create a streaming body from a fresh byte iterable factory."""
+        return cls(lambda: _streaming_iterable(factory()))
+
+    @classmethod
+    def async_iterable(cls, factory: Callable[[], AsyncIterable[StreamingBodyChunk]]) -> StreamingBody:
+        """Create a streaming body from a fresh async byte iterable factory."""
+        return cls(lambda: _streaming_async_iterable(factory()))
+
+    def content(self) -> StreamingBodyContent:
+        """Create the httpx request content for one request attempt."""
+        return self.factory()
 
 
 @dataclass(frozen=True, slots=True)
@@ -130,6 +175,33 @@ class Operation[ResponseT]:
     async def transport_response(self) -> TransportResponse:
         """Send the request and return the transport-specific response value."""
         return await self.transport.send(self.request)
+
+
+@dataclass(frozen=True, slots=True)
+class StreamingOperation[ResponseT]:
+    """A prepared streaming upload operation that builds a fresh request for each attempt."""
+
+    transport: Transport
+    build_request: Callable[[], TransportRequest]
+    decode: Callable[[Response], ResponseT]
+
+    async def execute(self) -> ResponseT:
+        """Send the request and decode the successful response body."""
+        return (await self.response()).result
+
+    async def response(self) -> OperationResponse[ResponseT]:
+        """Send the request and return the decoded response with metadata."""
+        response = await self.transport_response()
+        response.raise_for_status()
+        return OperationResponse(result=self.decode(response), transport_response=response)
+
+    def transport_request(self) -> TransportRequest:
+        """Return a fresh transport-specific request value."""
+        return self.build_request()
+
+    async def transport_response(self) -> TransportResponse:
+        """Send a fresh request and return the transport-specific response value."""
+        return await self.transport.send(self.build_request())
 
 
 @dataclass(frozen=True, slots=True)


### PR DESCRIPTION
Summary
- Add Python StreamingBody and StreamingOperation runtime helpers for reusable streaming upload requests.
- Emit Python httpx client streaming operations for IR request bodies marked streaming.
- Add compile-backed renderer and OpenAPI parity coverage for Python streaming request bodies.

Details
- StreamingBody supports bytes, iterable factories, and async iterable factories so each execution can build fresh httpx content.
- StreamingOperation mirrors Operation but rebuilds its request for execute, response, transportRequest, and transportResponse.
- Generated requests now set fixed payload Content-Type headers when no explicit Content-Type parameter owns the value.

Validation
- ./gradlew :generator:test --tests io.outfoxx.sunday.generator.python.PythonClientRendererTest --tests io.outfoxx.sunday.generator.python.PythonGeneratedOutputParityTest :generator:ktlintCheck --rerun-tasks
- ./gradlew :generator:check --rerun-tasks